### PR TITLE
Preserve IEEE 754 semantics and types in expression folds

### DIFF
--- a/docs/system/code-generation.md
+++ b/docs/system/code-generation.md
@@ -17,7 +17,7 @@ Language modules extend a base generator and add or override entries after calli
 
 `DefaultAstExpressionOptimizer` (`jcc-base`, shared by all languages and both backends) constant-folds expressions before code generation. Float folds must preserve IEEE 754 semantics — a fold may not change the result for NaN, ±inf, or signed-zero inputs. This is why `0.0 / x` is not folded to `0.0`, and why an overflowing literal division stays unfolded instead of becoming an inf literal. Division by a literal zero is rejected at compile time (`InvalidValueException`) — deliberate, Go-style; see `col-language.md`.
 
-Known gap: `mulExpression` still folds `0 * x` / `x * 0` to an integer literal `0`, which predates the IEEE rule and violates it for floats — tracked in [#50](https://github.com/dykstrom/jcc/issues/50).
+A fold that replaces an expression with one of its operands must also preserve the expression's static type: the zero-folds (`0 * x` → `0`, `0 + x` → `x`) apply only to integer-typed expressions, and the identity folds (`1 * x` → `x`, `x / 1` → `x`, `x - 0` → `x`) require the operand to have the same type as the expression — notably, a float division is float-typed even with integer operands. Folding two literals is always allowed, because the fold computes the exact IEEE 754 result at compile time.
 
 ## Storage allocation (FASM)
 

--- a/jcc-base/src/main/java/se/dykstrom/jcc/common/optimization/DefaultAstExpressionOptimizer.java
+++ b/jcc-base/src/main/java/se/dykstrom/jcc/common/optimization/DefaultAstExpressionOptimizer.java
@@ -193,9 +193,10 @@ public class DefaultAstExpressionOptimizer implements AstExpressionOptimizer {
      * Simplifies an add expression to a literal expression if possible.
      */
     private Expression addExpression(int line, int column, Expression left, Expression right) {
-        if (isZero(left)) {
+        final var addExpression = new AddExpression(line, column, left, right);
+        if (isIntegerZeroIdentity(left, right, addExpression)) {
             return right;
-        } else if (isZero(right)) {
+        } else if (isIntegerZeroIdentity(right, left, addExpression)) {
             return left;
         } else if (isIntegerLiteral(left) && isIntegerLiteral(right)) {
             return new IntegerLiteral(line, column, asLong(left) + asLong(right));
@@ -204,25 +205,24 @@ public class DefaultAstExpressionOptimizer implements AstExpressionOptimizer {
         } else if (isStringLiteral(left) && isStringLiteral(right)) {
             return new StringLiteral(line, column, asString(left) + asString(right));
         }
-        return new AddExpression(line, column, left, right);
+        return addExpression;
     }
 
     /**
      * Simplifies a sub expression to a literal expression if possible.
      */
     private Expression subExpression(int line, int column, Expression left, Expression right) {
-        if (isZero(left) && isIntegerLiteral(right)) {
-            return new IntegerLiteral(right.line(), right.column(), -asLong(right));
-        } else if (isZero(left) && isNumericLiteral(right)) {
-            return new FloatLiteral(right.line(), right.column(), -asDouble(right));
-        } else if (isZero(right)) {
+        final var subExpression = new SubExpression(line, column, left, right);
+        // Subtracting zero is an IEEE 754 identity also for floats (x - 0.0 == x for -0.0 and NaN),
+        // so the fold only needs to preserve the expression type
+        if (isZero(right) && sameTypeAs(left, subExpression)) {
             return left;
         } else if (isIntegerLiteral(left) && isIntegerLiteral(right)) {
             return new IntegerLiteral(line, column, asLong(left) - asLong(right));
         } else if (isNumericLiteral(left) && isNumericLiteral(right)) {
             return new FloatLiteral(line, column, asDouble(left) - asDouble(right));
         }
-        return new SubExpression(line, column, left, right);
+        return subExpression;
     }
 
     /**
@@ -230,13 +230,14 @@ public class DefaultAstExpressionOptimizer implements AstExpressionOptimizer {
      * the multiplication with a shift expression if that is possible.
      */
     private Expression mulExpression(int line, int column, Expression left, Expression right) {
-        if (isZero(left) && hasNoFunctionCall(right)) {
-            return new IntegerLiteral(line, column, 0);
-        } else if (isZero(right) && hasNoFunctionCall(left)) {
-            return new IntegerLiteral(line, column, 0);
-        } else if (isOne(left)) {
+        final var mulExpression = new MulExpression(line, column, left, right);
+        if (isIntegerZeroFold(left, right, mulExpression)) {
+            return new IntegerLiteral(line, column, 0L, typeManager.getType(mulExpression));
+        } else if (isIntegerZeroFold(right, left, mulExpression)) {
+            return new IntegerLiteral(line, column, 0L, typeManager.getType(mulExpression));
+        } else if (isOne(left) && sameTypeAs(right, mulExpression)) {
             return right;
-        } else if (isOne(right)) {
+        } else if (isOne(right) && sameTypeAs(left, mulExpression)) {
             return left;
         }
         return mulLiteralOrShiftExpression(line, column, left, right);
@@ -263,6 +264,7 @@ public class DefaultAstExpressionOptimizer implements AstExpressionOptimizer {
      * Simplifies a div expression to a literal expression if possible.
      */
     private Expression divExpression(int line, int column, Expression left, Expression right) {
+        final var divExpression = new DivExpression(line, column, left, right);
         // Folding 0.0 / x to 0.0 would violate IEEE 754: the result is -0.0 for negative x and NaN for NaN
         if (isZero(right)) {
             throw new InvalidValueException("division by zero: " + right, right.toString());
@@ -272,10 +274,12 @@ public class DefaultAstExpressionOptimizer implements AstExpressionOptimizer {
             if (Double.isFinite(result)) {
                 return new FloatLiteral(line, column, result);
             }
-        } else if (isOne(right)) {
+        } else if (isOne(right) && sameTypeAs(left, divExpression)) {
+            // Dividing by one is an IEEE 754 identity, but a float division is float-typed,
+            // so the fold must not replace it with an integer operand
             return left;
         }
-        return new DivExpression(line, column, left, right);
+        return divExpression;
     }
 
     /**
@@ -517,6 +521,33 @@ public class DefaultAstExpressionOptimizer implements AstExpressionOptimizer {
      */
     private boolean isIntegerType(Expression expression) {
         return typeManager.getType(expression).isInteger();
+    }
+
+    /**
+     * Returns {@code true} if the given operand has the same static type as the given expression,
+     * so that the expression can be replaced by the operand without changing its type.
+     */
+    private boolean sameTypeAs(Expression operand, Expression expression) {
+        return typeManager.getType(operand).equals(typeManager.getType(expression));
+    }
+
+    /**
+     * Returns {@code true} if {@code zero} is a zero literal and the whole expression is integer-typed,
+     * so that the expression can be folded to {@code operand}. For floats, this fold would violate
+     * IEEE 754: 0.0 + -0.0 is +0.0.
+     */
+    private boolean isIntegerZeroIdentity(Expression zero, Expression operand, Expression expression) {
+        return isZero(zero) && isIntegerType(expression) && sameTypeAs(operand, expression);
+    }
+
+    /**
+     * Returns {@code true} if {@code zero} is a zero literal and the whole expression is integer-typed,
+     * so that the expression can be folded to a zero literal. For floats, this fold would violate
+     * IEEE 754: 0.0 * inf is NaN, and 0.0 * -1.0 is -0.0. The discarded operand must not contain
+     * a function call, because functions may have side effects.
+     */
+    private boolean isIntegerZeroFold(Expression zero, Expression discarded, Expression expression) {
+        return isZero(zero) && hasNoFunctionCall(discarded) && isIntegerType(expression);
     }
 
     private static boolean isIntegerLiteral(Expression expression) {

--- a/jcc-base/src/test/kotlin/se/dykstrom/jcc/common/optimization/DefaultAstExpressionOptimizerTests.kt
+++ b/jcc-base/src/test/kotlin/se/dykstrom/jcc/common/optimization/DefaultAstExpressionOptimizerTests.kt
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.assertThrows
 import se.dykstrom.jcc.common.ast.*
 import se.dykstrom.jcc.common.ast.FloatLiteral.FL_F32_0_0
 import se.dykstrom.jcc.common.ast.IntegerLiteral.*
-import se.dykstrom.jcc.common.compiler.DefaultTypeManager
+import se.dykstrom.jcc.common.compiler.AbstractTypeManager
 import se.dykstrom.jcc.common.error.InvalidValueException
 import se.dykstrom.jcc.common.symbols.SymbolTable
 import se.dykstrom.jcc.common.types.*
@@ -72,6 +72,43 @@ class DefaultAstExpressionOptimizerTests {
 
         // Then
         assertEquals(IDE_I64_A, optimizedExpression)
+    }
+
+    @Test
+    fun shouldNotReplaceAddFloatZeroAndIde() {
+        // Folding 0.0 + x to x would violate IEEE 754: the result is +0.0 when x is -0.0
+        // Given
+        val addExpression = AddExpression(0, 0, FL_0_0, IDE_F64_F)
+
+        // When
+        val optimizedExpression = expressionOptimizer.expression(addExpression, symbolTable)
+
+        // Then
+        assertEquals(addExpression, optimizedExpression)
+    }
+
+    @Test
+    fun shouldNotReplaceAddFloatIdeAndZero() {
+        // Given
+        val addExpression = AddExpression(0, 0, IDE_F64_F, FL_0_0)
+
+        // When
+        val optimizedExpression = expressionOptimizer.expression(addExpression, symbolTable)
+
+        // Then
+        assertEquals(addExpression, optimizedExpression)
+    }
+
+    @Test
+    fun shouldNotReplaceAddIntegerZeroAndFloatIde() {
+        // Given
+        val addExpression = AddExpression(0, 0, IL_0, IDE_F64_F)
+
+        // When
+        val optimizedExpression = expressionOptimizer.expression(addExpression, symbolTable)
+
+        // Then
+        assertEquals(addExpression, optimizedExpression)
     }
 
     @Test
@@ -220,6 +257,45 @@ class DefaultAstExpressionOptimizerTests {
     }
 
     @Test
+    fun shouldReplaceSubFloatIdeAndZeroWithIde() {
+        // Subtracting zero is an IEEE 754 identity, so the fold is valid also for floats
+        // Given
+        val subExpression = SubExpression(0, 0, IDE_F64_F, FL_0_0)
+
+        // When
+        val optimizedExpression = expressionOptimizer.expression(subExpression, symbolTable)
+
+        // Then
+        assertEquals(IDE_F64_F, optimizedExpression)
+    }
+
+    @Test
+    fun shouldNotReplaceSubIntegerIdeAndFloatZero() {
+        // The expression is float-typed, so folding it to the integer identifier would change its type
+        // Given
+        val subExpression = SubExpression(0, 0, IDE_I64_A, FL_0_0)
+
+        // When
+        val optimizedExpression = expressionOptimizer.expression(subExpression, symbolTable)
+
+        // Then
+        assertEquals(subExpression, optimizedExpression)
+    }
+
+    @Test
+    fun shouldReplaceSubFloatZeroAndIntegerWithFloatLiteral() {
+        // Given
+        val subExpression = SubExpression(0, 0, FL_0_0, IL_1)
+
+        // When
+        val optimizedExpression = expressionOptimizer.expression(subExpression, symbolTable)
+
+        // Then
+        assertEquals(FloatLiteral::class.java, optimizedExpression.javaClass)
+        assertEquals(-1.0, (optimizedExpression as FloatLiteral).asDouble())
+    }
+
+    @Test
     fun shouldNotReplaceSubLiteralAndFunctionCall() {
         // Given
         val subExpression = SubExpression(0, 0, IL_1, FCE_FOO)
@@ -265,6 +341,69 @@ class DefaultAstExpressionOptimizerTests {
 
         // Then
         assertEquals(IDE_I64_A, optimizedExpression)
+    }
+
+    @Test
+    fun shouldNotReplaceMulFloatZeroAndIde() {
+        // Folding 0.0 * x to 0.0 would violate IEEE 754: 0.0 * inf is NaN and 0.0 * -1.0 is -0.0
+        // Given
+        val mulExpression = MulExpression(0, 0, FL_0_0, IDE_F64_F)
+
+        // When
+        val optimizedExpression = expressionOptimizer.expression(mulExpression, symbolTable)
+
+        // Then
+        assertEquals(mulExpression, optimizedExpression)
+    }
+
+    @Test
+    fun shouldNotReplaceMulIntegerZeroAndFloatIde() {
+        // Given
+        val mulExpression = MulExpression(0, 0, IL_0, IDE_F64_F)
+
+        // When
+        val optimizedExpression = expressionOptimizer.expression(mulExpression, symbolTable)
+
+        // Then
+        assertEquals(mulExpression, optimizedExpression)
+    }
+
+    @Test
+    fun shouldPreserveSignWhenFoldingMulFloatZeroLiterals() {
+        // Given
+        val mulExpression = MulExpression(0, 0, FL_0_0, FL_M1_0)
+
+        // When
+        val optimizedExpression = expressionOptimizer.expression(mulExpression, symbolTable)
+
+        // Then
+        assertEquals(FloatLiteral::class.java, optimizedExpression.javaClass)
+        assertEquals(-0.0, (optimizedExpression as FloatLiteral).asDouble())
+    }
+
+    @Test
+    fun shouldReplaceMulOneAndFloatIdeWithIde() {
+        // Given
+        val mulExpression = MulExpression(0, 0, IL_1, IDE_F64_F)
+
+        // When
+        val optimizedExpression = expressionOptimizer.expression(mulExpression, symbolTable)
+
+        // Then
+        assertEquals(IDE_F64_F, optimizedExpression)
+    }
+
+    @Test
+    fun shouldNotReplaceMulFloatOneAndIntegerIde() {
+        // The expression is float-typed, so folding it to the integer identifier would change its type
+        // Given
+        val mulExpression = MulExpression(0, 0, FL_1_0, IDE_I64_A)
+
+        // When
+        val optimizedExpression = expressionOptimizer.expression(mulExpression, symbolTable)
+
+        // Then
+        assertEquals(mulExpression, optimizedExpression)
     }
 
     @Test
@@ -377,6 +516,31 @@ class DefaultAstExpressionOptimizerTests {
 
         // Then
         assertEquals(FL_3_14, optimizedExpression)
+    }
+
+    @Test
+    fun shouldReplaceDivFloatIdeByOneWithIde() {
+        // Given
+        val divExpression = DivExpression(0, 0, IDE_F64_F, IL_1)
+
+        // When
+        val optimizedExpression = expressionOptimizer.expression(divExpression, symbolTable)
+
+        // Then
+        assertEquals(IDE_F64_F, optimizedExpression)
+    }
+
+    @Test
+    fun shouldNotReplaceDivIntegerIdeByOne() {
+        // A float division is float-typed, so folding it to the integer identifier would change its type
+        // Given
+        val divExpression = DivExpression(0, 0, IDE_I64_A, IL_1)
+
+        // When
+        val optimizedExpression = expressionOptimizer.expression(divExpression, symbolTable)
+
+        // Then
+        assertEquals(divExpression, optimizedExpression)
     }
 
     @Test
@@ -841,6 +1005,7 @@ class DefaultAstExpressionOptimizerTests {
         private val FL_2_25 = FloatLiteral(0, 0, "2.25")
         private val FL_3_14 = FloatLiteral(0, 0, "3.14")
         private val FL_4_14 = FloatLiteral(0, 0, "4.14")
+        private val FL_M1_0 = FloatLiteral(0, 0, "-1.0")
         private val FL_M3_14 = FloatLiteral(0, 0, "-3.14")
 
         private val IL_0 = IntegerLiteral(0, 0, "0")
@@ -857,14 +1022,20 @@ class DefaultAstExpressionOptimizerTests {
         private val IDENT_I64_A = Identifier("a%", I64.INSTANCE)
         private val IDE_I64_A = IdentifierDerefExpression(0, 0, IDENT_I64_A)
 
+        private val IDENT_F64_F = Identifier("f#", F64.INSTANCE)
+        private val IDE_F64_F = IdentifierDerefExpression(0, 0, IDENT_F64_F)
+
         private val IDENT_STR_S = Identifier("s$", Str.INSTANCE)
         private val IDE_STR_S = IdentifierDerefExpression(0, 0, IDENT_STR_S)
 
-        private val FCE_FOO = FunctionCallExpression(0, 0, Identifier("foo", I64.INSTANCE), listOf(IL_1))
+        private val FCE_FOO = FunctionCallExpression(0, 0, Identifier("foo", Fun.from(listOf(I64.INSTANCE), I64.INSTANCE)), listOf(IL_1))
 
-        // We have to use the default type manager here, since we don't have access to any other.
-        // If this becomes a problem for the tests, we will have to make the default type manager
-        // more advanced.
-        private val expressionOptimizer = DefaultAstExpressionOptimizer(DefaultTypeManager())
+        // A minimal type manager that uses the type computation inherited from AbstractTypeManager,
+        // so that the tests can verify folds that depend on integer and float operand types
+        private val typeManager = object : AbstractTypeManager() {
+            override fun getTypeName(type: Type): String = type.javaClass.simpleName
+            override fun isAssignableFrom(thisType: Type, thatType: Type): Boolean = thisType == thatType
+        }
+        private val expressionOptimizer = DefaultAstExpressionOptimizer(typeManager)
     }
 }


### PR DESCRIPTION
## What is this

The AST optimizer folded `0 * x` and `0 + x` for float operands, changing
observable results (`0.0 * inf` is NaN, `0.0 * -1.0` is -0.0) and replacing
float-typed expressions with integer literals. This brings the zero- and
identity-folds in line with the IEEE 754 convention already used by the
division folds. Fixes #50.

## Approach

- **Zero-folds are integer-only:** folding `0 * x` / `0 + x` is unsound for
  any non-literal float operand
- **Identity folds require type equality:** `1 * x`, `x / 1`, `x - 0` fold
  only when the operand's static type equals the expression's — a float
  division is `F64` even with integer operands
- **`x - 0` still folds for floats:** subtracting +0.0 is a true IEEE 754
  identity, so only the type guard applies
- **`0 - literal` branches deleted:** the general literal folds compute the
  same result with the correct type (previously `0.0 - 5` became integer `-5`)
- **Tests use a real type manager:** a minimal `AbstractTypeManager` subclass
  replaces `DefaultTypeManager`, which types everything `I64` and hid the
  float cases

## Risks / follow-ups

- **FASM regression references:** generated assembly changes wherever a
  no-longer-valid fold used to apply; `regression_test` on Windows may need
  reference files regenerated
- **Integer-only folds untouched:** IDIV/MOD/AND/OR zero- and one-folds keep
  their existing shape; they cannot involve floats

## Updated context

- Docs: `docs/system/code-generation.md` — "known gap" paragraph replaced with
  the type-preservation rule for operand folds

## How to verify

- Compile and run (LLVM backend): `LET X# = -1.0 : PRINT 0 * X#` — prints
  `-0.000000` instead of `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
