### PR TITLE
Improve COL error messages by verifying rules in semantics (#56)

### DIFF
--- a/docs/system/col-error-reporting.md
+++ b/docs/system/col-error-reporting.md
@@ -1,0 +1,16 @@
+# COL error reporting
+
+The COL front-end keeps the grammar (`Col.g4`) liberal and rejects language-rule violations during semantic analysis, so errors name the broken rule instead of producing ANTLR token dumps. Because the parse succeeds, one mistake no longer discards the rest of the input: independent errors accumulate in `CompilationErrorListener` and are thrown together at the end of `ColSemanticsParser.parse`.
+
+Adding a rule of this kind follows a fixed shape:
+
+1. Widen the rule in `Col.g4` so the malformed form parses.
+2. In `ColSyntaxVisitor`, carry the violation into the AST — either a flag on a statement node (`FunCallStatement.hasCall`, `ValDeclarationStatement.usesEquals`) or a dedicated marker expression node (`ChainedRelationalExpression`, `MalformedFloatLiteral`).
+3. Report it from a semantics component that calls `reportError`. Expression markers get an `ExpressionSemanticsParser` registered by node class in `ColSemanticsParser`; statement-level checks live in the relevant statement parser (`FunCallSemanticsParser`, `ValSemanticsParser`, `FunDefPass1SemanticsParser`).
+
+Marker expression nodes implement `TypedExpression` and return the type the construct would have if it were valid (`ChainedRelationalExpression` returns `Bool`, `MalformedFloatLiteral` returns `F64`), so overload resolution does not fail before the dedicated error is reported.
+
+Two details that are easy to get wrong:
+
+- Chained relational operators are detected by parse shape — a relational whose left operand is itself an unparenthesized relational — not by operand types, so `(a == b) == c` is left alone while `1 < 2 < 3` is rejected.
+- The missing-`else` check lives in the shared `IfSemanticsParser` in `jcc-base`, not a COL-specific parser; `IfExpression` and `AbstractTypeManager` tolerate a null else so that check is what reports it. Only COL uses these shared classes today.

--- a/docs/system/col-language.md
+++ b/docs/system/col-language.md
@@ -33,7 +33,7 @@ COL has two ways to loop: the `while` loop and recursion. Deep recursion should 
 
 `i32`, `i64`, `f32`, `f64`, `bool`, and function types written `(i64, i64) -> i64`. Integer literals default to `i64`, float literals to `f64`. `void` is not a usable type name (it appears only in FASM import signatures). There is no string type yet.
 
-Literals: decimal with optional `_` separators (`10_000`), binary `0b0010`, hex `0xfe` (lowercase digits), floats `0.99`, `1.5`, `1E9`, booleans `true`/`false`. A decimal point must have digits on both sides: `.99` and `17.` are syntax errors — write `0.99` and `17.0`.
+Literals: decimal with optional `_` separators (`10_000`), binary `0b0010`, hex `0xfe` (digits in either case: `0xfe` ≡ `0xFE`), floats `0.99`, `1.5`, `1e9` (exponent marker `e` or `E`), booleans `true`/`false`. A decimal point must have digits on both sides: `.99` and `17.` are rejected — the compiler reports *a decimal point must have digits on both sides* — write `0.99` and `17.0`.
 
 Decimal literals take an optional Rust-style type suffix naming one of the scalar numeric types: `17i32`, `17i64`, `1.5f32`, `1E9f64`, `10_000i32`. A float suffix on an integer-shaped literal is allowed (`17f32` ≡ `17.0f32`); the reverse is a syntax error (`1.5i32`). Hex and binary literals take no suffix (`0x17i32` and `0b101i64` are syntax errors; note `f` is a hex digit, so `0x17f32` is just a hex number). A value outside the suffixed type's range is a compile-time error (`5000000000i32`, `3.5E39f32`); boundary values like `-2147483648i32` are accepted. A suffixed literal behaves like any other expression of that type — implicit widening still applies (`17i32 + 1` is `i64`), and mixed int/float arithmetic still errors.
 

--- a/jcc-base/src/main/java/se/dykstrom/jcc/common/ast/IfExpression.java
+++ b/jcc-base/src/main/java/se/dykstrom/jcc/common/ast/IfExpression.java
@@ -40,7 +40,8 @@ public class IfExpression extends AbstractNode implements Expression {
         super(line, column);
         this.ifExpr = requireNonNull(ifExpr);
         this.thenExpr = requireNonNull(thenExpr);
-        this.elseExpr = requireNonNull(elseExpr);
+        // A null else branch is allowed through parsing; IfSemanticsParser reports it as an error
+        this.elseExpr = elseExpr;
     }
 
     public IfExpression(final Expression ifExpr,

--- a/jcc-base/src/main/java/se/dykstrom/jcc/common/compiler/AbstractTypeManager.java
+++ b/jcc-base/src/main/java/se/dykstrom/jcc/common/compiler/AbstractTypeManager.java
@@ -94,6 +94,10 @@ public abstract class AbstractTypeManager implements TypeManager {
 
     private Type ifExpression(final IfExpression expression) {
         final var tt = getType(expression.thenExpr());
+        if (expression.elseExpr() == null) {
+            // A missing else branch is reported by IfSemanticsParser; fall back to the then type here
+            return tt;
+        }
         final var et = getType(expression.elseExpr());
 
         if (tt.equals(et)) {

--- a/jcc-base/src/main/java/se/dykstrom/jcc/common/semantics/expression/IfSemanticsParser.java
+++ b/jcc-base/src/main/java/se/dykstrom/jcc/common/semantics/expression/IfSemanticsParser.java
@@ -38,6 +38,12 @@ public class IfSemanticsParser<T extends TypeManager> extends AbstractSemanticsP
 
     @Override
     public Expression parse(final IfExpression expression) {
+        if (expression.elseExpr() == null) {
+            final var msg = "if-expression requires an 'else' branch — an expression must produce a value on every path";
+            reportError(expression, msg, new SemanticsException(msg));
+            return expression;
+        }
+
         final var ifExpr = parser.expression(expression.ifExpr());
         final var thenExpr = parser.expression(expression.thenExpr());
         final var elseExpr = parser.expression(expression.elseExpr());

--- a/jcc-col/src/main/antlr4/se/dykstrom/jcc/col/compiler/Col.g4
+++ b/jcc-col/src/main/antlr4/se/dykstrom/jcc/col/compiler/Col.g4
@@ -52,7 +52,7 @@ importStmt
    ;
 
 valStmt
-   : VAL ident (AS type)? (ASSIGN expr)?
+   : VAL ident (AS type)? ((ASSIGN | EQUALS) expr)?
    ;
 
 whileStmt
@@ -299,6 +299,8 @@ COMMA : ',' ;
 DOT : '.' ;
 
 EQ : '==' ;
+
+EQUALS : '=' ;
 
 GE : '>=' ;
 

--- a/jcc-col/src/main/antlr4/se/dykstrom/jcc/col/compiler/Col.g4
+++ b/jcc-col/src/main/antlr4/se/dykstrom/jcc/col/compiler/Col.g4
@@ -95,12 +95,12 @@ andExpr
    ;
 
 relExpr
-   : addExpr EQ addExpr
-   | addExpr GE addExpr
-   | addExpr GT addExpr
-   | addExpr LE addExpr
-   | addExpr LT addExpr
-   | addExpr NE addExpr
+   : relExpr EQ addExpr
+   | relExpr GE addExpr
+   | relExpr GT addExpr
+   | relExpr LE addExpr
+   | relExpr LT addExpr
+   | relExpr NE addExpr
    | addExpr
    ;
 

--- a/jcc-col/src/main/antlr4/se/dykstrom/jcc/col/compiler/Col.g4
+++ b/jcc-col/src/main/antlr4/se/dykstrom/jcc/col/compiler/Col.g4
@@ -40,6 +40,7 @@ aliasStmt
 
 functionCallStmt
    : CALL functionCall
+   | functionCall
    ;
 
 functionDefinitionStmt

--- a/jcc-col/src/main/antlr4/se/dykstrom/jcc/col/compiler/Col.g4
+++ b/jcc-col/src/main/antlr4/se/dykstrom/jcc/col/compiler/Col.g4
@@ -44,7 +44,7 @@ functionCallStmt
    ;
 
 functionDefinitionStmt
-   : FUN ident OPEN (ident AS type (COMMA ident AS type)*)? CLOSE ARROW returnType ASSIGN expr
+   : FUN ident OPEN (ident (AS type)? (COMMA ident (AS type)?)*)? CLOSE (ARROW returnType)? ASSIGN expr
    ;
 
 importStmt

--- a/jcc-col/src/main/antlr4/se/dykstrom/jcc/col/compiler/Col.g4
+++ b/jcc-col/src/main/antlr4/se/dykstrom/jcc/col/compiler/Col.g4
@@ -140,6 +140,7 @@ booleanLiteral
 floatLiteral
    : FLOAT_NUMBER
    | DEC_NUMBER_FLOAT_TYPED
+   | MALFORMED_FLOAT
    ;
 
 integerLiteral
@@ -236,7 +237,7 @@ DEC_NUMBER_FLOAT_TYPED
    ;
 
 HEX_NUMBER
-   : '0' 'x' [0-9a-f_]+
+   : '0' 'x' [0-9a-fA-F_]+
    ;
 
 LETTERS
@@ -248,9 +249,16 @@ FLOAT_NUMBER
    | DEC_NUMBER EXPONENT FLOAT_SUFFIX?
    ;
 
+// A decimal point with digits on only one side, e.g. '.99' or '17.'. Rejected in semantic
+// analysis with a message naming the rule; valid floats match the longer FLOAT_NUMBER first.
+MALFORMED_FLOAT
+   : DOT DEC_NUMBER
+   | DEC_NUMBER DOT
+   ;
+
 fragment
 EXPONENT
-   : 'E' SIGN? DEC_NUMBER
+   : [eE] SIGN? DEC_NUMBER
    ;
 
 fragment

--- a/jcc-col/src/main/antlr4/se/dykstrom/jcc/col/compiler/Col.g4
+++ b/jcc-col/src/main/antlr4/se/dykstrom/jcc/col/compiler/Col.g4
@@ -158,7 +158,7 @@ functionCall
    ;
 
 ifExpr
-   : IF expr THEN expr ELSE expr
+   : IF expr THEN expr (ELSE expr)?
    ;
 
 libFunIdent

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/ast/expression/ChainedRelationalExpression.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/ast/expression/ChainedRelationalExpression.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Johan Dykstrom
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.dykstrom.jcc.col.ast.expression;
+
+import se.dykstrom.jcc.common.ast.AbstractNode;
+import se.dykstrom.jcc.common.ast.Expression;
+import se.dykstrom.jcc.common.ast.TypedExpression;
+import se.dykstrom.jcc.common.types.Bool;
+import se.dykstrom.jcc.common.types.Type;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Marks a relational expression synthesized from an unparenthesized chain, such as '1 &lt; 2 &lt; 3'.
+ * Relational operators cannot be chained; this is rejected during semantic analysis. The marker is
+ * keyed on parse shape (an unparenthesized relational as the left operand), not on operand types,
+ * so legitimately type-correct forms like '(a == b) == c' are not flagged.
+ *
+ * @author Johan Dykstrom
+ */
+public class ChainedRelationalExpression extends AbstractNode implements TypedExpression {
+
+    private final Expression expression;
+
+    public ChainedRelationalExpression(final int line, final int column, final Expression expression) {
+        super(line, column);
+        this.expression = requireNonNull(expression);
+    }
+
+    public ChainedRelationalExpression(final Expression expression) {
+        this(0, 0, expression);
+    }
+
+    /**
+     * A relational expression would be of type bool, were chaining allowed.
+     */
+    @Override
+    public Type type() {
+        return Bool.INSTANCE;
+    }
+
+    /**
+     * Returns the wrapped relational expression.
+     */
+    public Expression expression() {
+        return expression;
+    }
+
+    @Override
+    public String toString() {
+        return expression.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChainedRelationalExpression that = (ChainedRelationalExpression) o;
+        return Objects.equals(expression, that.expression);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expression);
+    }
+}

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/ast/expression/MalformedFloatLiteral.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/ast/expression/MalformedFloatLiteral.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Johan Dykstrom
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.dykstrom.jcc.col.ast.expression;
+
+import se.dykstrom.jcc.common.ast.AbstractNode;
+import se.dykstrom.jcc.common.ast.TypedExpression;
+import se.dykstrom.jcc.common.types.F64;
+import se.dykstrom.jcc.common.types.Type;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Marks a float literal written with a decimal point on only one side, such as '.99' or '17.'.
+ * COL requires digits on both sides of the point; this is rejected during semantic analysis.
+ *
+ * @author Johan Dykstrom
+ */
+public class MalformedFloatLiteral extends AbstractNode implements TypedExpression {
+
+    private final String value;
+
+    public MalformedFloatLiteral(final int line, final int column, final String value) {
+        super(line, column);
+        this.value = requireNonNull(value);
+    }
+
+    public MalformedFloatLiteral(final String value) {
+        this(0, 0, value);
+    }
+
+    /**
+     * A float literal would be of type f64, were it well-formed.
+     */
+    @Override
+    public Type type() {
+        return F64.INSTANCE;
+    }
+
+    /**
+     * Returns the malformed literal text as written in the source.
+     */
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MalformedFloatLiteral that = (MalformedFloatLiteral) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/ast/statement/FunCallStatement.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/ast/statement/FunCallStatement.java
@@ -33,30 +33,41 @@ import static java.util.Objects.requireNonNull;
 public class FunCallStatement extends AbstractNode implements Statement {
 
     private final FunctionCallExpression expression;
+    /** Whether the call was written with the leading 'call' keyword; a bare call is a semantic error. */
+    private final boolean hasCall;
 
-    public FunCallStatement(final int line, final int column, final FunctionCallExpression expression) {
+    public FunCallStatement(final int line, final int column, final FunctionCallExpression expression, final boolean hasCall) {
         super(line, column);
         this.expression = requireNonNull(expression);
+        this.hasCall = hasCall;
+    }
+
+    public FunCallStatement(final int line, final int column, final FunctionCallExpression expression) {
+        this(line, column, expression, true);
     }
 
     public FunCallStatement(final FunctionCallExpression expression) {
-        this(0, 0, expression);
+        this(0, 0, expression, true);
     }
 
     @Override
     public String toString() {
-        return "call " + expression.toString();
+        return (hasCall ? "call " : "") + expression.toString();
     }
 
     public FunctionCallExpression expression() {
         return expression;
     }
 
+    public boolean hasCall() {
+        return hasCall;
+    }
+
     /**
      * Returns a copy of this statement, with the expression set to {@code expression}.
      */
     public FunCallStatement withExpression(final FunctionCallExpression expression) {
-        return new FunCallStatement(line(), column(), expression);
+        return new FunCallStatement(line(), column(), expression, hasCall);
     }
 
     @Override
@@ -68,11 +79,11 @@ public class FunCallStatement extends AbstractNode implements Statement {
             return false;
         }
         final FunCallStatement that = (FunCallStatement) o;
-        return Objects.equals(expression, that.expression);
+        return hasCall == that.hasCall && Objects.equals(expression, that.expression);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(expression);
+        return Objects.hash(expression, hasCall);
     }
 }

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/ast/statement/ValDeclarationStatement.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/ast/statement/ValDeclarationStatement.java
@@ -33,14 +33,21 @@ import static java.util.Objects.requireNonNull;
 public class ValDeclarationStatement extends AbstractNode implements Statement {
 
     private final DeclarationAssignment declaration;
+    /** Whether the binding used '=' instead of ':='; a semantic error reported in ValSemanticsParser. */
+    private final boolean usesEquals;
 
-    public ValDeclarationStatement(final int line, final int column, final DeclarationAssignment declaration) {
+    public ValDeclarationStatement(final int line, final int column, final DeclarationAssignment declaration, final boolean usesEquals) {
         super(line, column);
         this.declaration = requireNonNull(declaration);
+        this.usesEquals = usesEquals;
+    }
+
+    public ValDeclarationStatement(final int line, final int column, final DeclarationAssignment declaration) {
+        this(line, column, declaration, false);
     }
 
     public ValDeclarationStatement(final DeclarationAssignment declaration) {
-        this(0, 0, declaration);
+        this(0, 0, declaration, false);
     }
 
     @Override
@@ -54,8 +61,12 @@ public class ValDeclarationStatement extends AbstractNode implements Statement {
         return declaration;
     }
 
+    public boolean usesEquals() {
+        return usesEquals;
+    }
+
     public ValDeclarationStatement withDeclaration(final DeclarationAssignment declaration) {
-        return new ValDeclarationStatement(line(), column(), declaration);
+        return new ValDeclarationStatement(line(), column(), declaration, usesEquals);
     }
 
     @Override
@@ -67,11 +78,11 @@ public class ValDeclarationStatement extends AbstractNode implements Statement {
             return false;
         }
         final ValDeclarationStatement that = (ValDeclarationStatement) o;
-        return Objects.equals(declaration, that.declaration);
+        return usesEquals == that.usesEquals && Objects.equals(declaration, that.declaration);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(declaration);
+        return Objects.hash(declaration, usesEquals);
     }
 }

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSemanticsParser.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSemanticsParser.java
@@ -19,6 +19,7 @@ package se.dykstrom.jcc.col.compiler;
 
 import se.dykstrom.jcc.col.ast.expression.BecomeExpression;
 import se.dykstrom.jcc.col.ast.expression.ChainedRelationalExpression;
+import se.dykstrom.jcc.col.ast.expression.MalformedFloatLiteral;
 import se.dykstrom.jcc.col.ast.statement.AliasStatement;
 import se.dykstrom.jcc.col.ast.statement.FunCallStatement;
 import se.dykstrom.jcc.col.ast.statement.ImportStatement;
@@ -26,6 +27,7 @@ import se.dykstrom.jcc.col.ast.statement.ValDeclarationStatement;
 import se.dykstrom.jcc.col.semantics.BecomeSemanticsUtils;
 import se.dykstrom.jcc.col.semantics.expression.BecomeSemanticsParser;
 import se.dykstrom.jcc.col.semantics.expression.ChainedRelationalSemanticsParser;
+import se.dykstrom.jcc.col.semantics.expression.MalformedFloatSemanticsParser;
 import se.dykstrom.jcc.col.semantics.statement.AliasPass1SemanticsParser;
 import se.dykstrom.jcc.col.semantics.statement.FunCallSemanticsParser;
 import se.dykstrom.jcc.col.semantics.statement.FunDefPass1SemanticsParser;
@@ -128,6 +130,7 @@ public class ColSemanticsParser extends AbstractSemanticsParser<ColTypeManager> 
         expressionComponents.put(AndExpression.class, new BitwiseBinarySemanticsParser<>(this, "and"));
         expressionComponents.put(BecomeExpression.class, new BecomeSemanticsParser<>(this));
         expressionComponents.put(ChainedRelationalExpression.class, new ChainedRelationalSemanticsParser<>(this));
+        expressionComponents.put(MalformedFloatLiteral.class, new MalformedFloatSemanticsParser<>(this));
         expressionComponents.put(DivExpression.class, new DivSemanticsParser<>(this));
         expressionComponents.put(EqualExpression.class, new EqualSemanticsParser<>(this));
         expressionComponents.put(FloatLiteral.class, new FloatSemanticsParser<>(this));

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSemanticsParser.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSemanticsParser.java
@@ -18,12 +18,14 @@
 package se.dykstrom.jcc.col.compiler;
 
 import se.dykstrom.jcc.col.ast.expression.BecomeExpression;
+import se.dykstrom.jcc.col.ast.expression.ChainedRelationalExpression;
 import se.dykstrom.jcc.col.ast.statement.AliasStatement;
 import se.dykstrom.jcc.col.ast.statement.FunCallStatement;
 import se.dykstrom.jcc.col.ast.statement.ImportStatement;
 import se.dykstrom.jcc.col.ast.statement.ValDeclarationStatement;
 import se.dykstrom.jcc.col.semantics.BecomeSemanticsUtils;
 import se.dykstrom.jcc.col.semantics.expression.BecomeSemanticsParser;
+import se.dykstrom.jcc.col.semantics.expression.ChainedRelationalSemanticsParser;
 import se.dykstrom.jcc.col.semantics.statement.AliasPass1SemanticsParser;
 import se.dykstrom.jcc.col.semantics.statement.FunCallSemanticsParser;
 import se.dykstrom.jcc.col.semantics.statement.FunDefPass1SemanticsParser;
@@ -125,6 +127,7 @@ public class ColSemanticsParser extends AbstractSemanticsParser<ColTypeManager> 
         expressionComponents.put(AddExpression.class, new AddSemanticsParser<>(this));
         expressionComponents.put(AndExpression.class, new BitwiseBinarySemanticsParser<>(this, "and"));
         expressionComponents.put(BecomeExpression.class, new BecomeSemanticsParser<>(this));
+        expressionComponents.put(ChainedRelationalExpression.class, new ChainedRelationalSemanticsParser<>(this));
         expressionComponents.put(DivExpression.class, new DivSemanticsParser<>(this));
         expressionComponents.put(EqualExpression.class, new EqualSemanticsParser<>(this));
         expressionComponents.put(FloatLiteral.class, new FloatSemanticsParser<>(this));

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
@@ -92,15 +92,11 @@ public class ColSyntaxVisitor extends ColBaseVisitor<Node> {
         final var line = ctx.getStart().getLine();
         final var column = ctx.getStart().getCharPositionInLine();
         final var functionName = ctx.ident(0).getText();
+        // A missing return type resolves to void, reported in FunDefPass1SemanticsParser
         final var returnType = getType(ctx.returnType());
         final var expression = (Expression) ctx.expr().accept(this);
 
-        final List<Declaration> declarations = new ArrayList<>();
-        // Ident index starts at 1 while type index starts at 0,
-        // because the first ident is the function name
-        for (int i = 1; i < ctx.ident().size(); i++) {
-            declarations.add(createDeclaration(ctx, i));
-        }
+        final var declarations = createDeclarations(ctx);
         final var argTypes = declarations.stream().map(Declaration::type).toList();
 
         final var functionType = Fun.from(argTypes, returnType);
@@ -108,12 +104,36 @@ public class ColSyntaxVisitor extends ColBaseVisitor<Node> {
         return new FunctionDefinitionStatement(line, column, functionIdentifier, declarations, expression);
     }
 
-    private static Declaration createDeclaration(final FunctionDefinitionStmtContext ctx, final int index) {
-        final var argLine = ctx.ident(index).getStart().getLine();
-        final var argColumn = ctx.ident(index).getStart().getCharPositionInLine();
-        final var argName = ctx.ident(index).getText();
-        final var argType = getType(ctx.type(index - 1));
-        return new Declaration(argLine, argColumn, argName, argType);
+    /**
+     * Pairs each parameter name with its optional {@code as type}. A parameter has a type exactly
+     * when an {@code as} token immediately follows its name; the parameter types appear in the same
+     * order, so they are consumed in sequence. A parameter whose type is omitted is recorded as void
+     * and reported in {@code FunDefPass1SemanticsParser}.
+     */
+    private static List<Declaration> createDeclarations(final FunctionDefinitionStmtContext ctx) {
+        final List<Declaration> declarations = new ArrayList<>();
+        int typeIndex = 0;
+        // ident(0) is the function name; parameters start at index 1
+        for (int i = 1; i < ctx.ident().size(); i++) {
+            final var identCtx = ctx.ident(i);
+            final var typeCtx = hasTypeAfter(identCtx, ctx) ? ctx.type(typeIndex++) : null;
+            declarations.add(createDeclaration(identCtx, typeCtx));
+        }
+        return declarations;
+    }
+
+    private static boolean hasTypeAfter(final IdentContext identCtx, final FunctionDefinitionStmtContext ctx) {
+        final var nextTokenIndex = identCtx.getStop().getTokenIndex() + 1;
+        return ctx.AS().stream().anyMatch(as -> as.getSymbol().getTokenIndex() == nextTokenIndex);
+    }
+
+    private static Declaration createDeclaration(final IdentContext identCtx, final TypeContext typeCtx) {
+        final var line = identCtx.getStart().getLine();
+        final var column = identCtx.getStart().getCharPositionInLine();
+        final var name = identCtx.getText();
+        // A null type context resolves to void, reported in FunDefPass1SemanticsParser
+        final var type = getType(typeCtx);
+        return new Declaration(line, column, name, type);
     }
 
     @Override

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
@@ -332,7 +332,8 @@ public class ColSyntaxVisitor extends ColBaseVisitor<Node> {
         final var column = ctx.getStart().getCharPositionInLine();
         final var ifExpr = (Expression) ctx.expr(0).accept(this);
         final var thenExpr = (Expression) ctx.expr(1).accept(this);
-        final var elseExpr = (Expression) ctx.expr(2).accept(this);
+        // A missing else branch is a semantic error, reported in IfSemanticsParser
+        final var elseExpr = isValid(ctx.expr(2)) ? (Expression) ctx.expr(2).accept(this) : null;
         return new IfExpression(line, column, ifExpr, thenExpr, elseExpr);
     }
 

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
@@ -82,7 +82,7 @@ public class ColSyntaxVisitor extends ColBaseVisitor<Node> {
         final var line = ctx.getStart().getLine();
         final var column = ctx.getStart().getCharPositionInLine();
         final var fce = (FunctionCallExpression) ctx.functionCall().accept(this);
-        return new FunCallStatement(line, column, fce);
+        return new FunCallStatement(line, column, fce, isValid(ctx.CALL()));
     }
 
     @Override

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
@@ -21,6 +21,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import se.dykstrom.jcc.col.ast.expression.BecomeExpression;
 import se.dykstrom.jcc.col.ast.expression.ChainedRelationalExpression;
+import se.dykstrom.jcc.col.ast.expression.MalformedFloatLiteral;
 import se.dykstrom.jcc.col.ast.statement.AliasStatement;
 import se.dykstrom.jcc.col.ast.statement.FunCallStatement;
 import se.dykstrom.jcc.col.ast.statement.ImportStatement;
@@ -55,7 +56,7 @@ public class ColSyntaxVisitor extends ColBaseVisitor<Node> {
     // Group 4 = complete exponent
     // Group 5 = optional exponent sign
     // Group 6 = optional type suffix
-    private static final Pattern FLOAT_PATTERN = Pattern.compile("^(-)?(\\d+(\\.\\d+)?)(E([-+])?\\d+)?(f32|f64)?$");
+    private static final Pattern FLOAT_PATTERN = Pattern.compile("^(-)?(\\d+(\\.\\d+)?)([eE]([-+])?\\d+)?(f32|f64)?$");
 
     @Override
     public Node visitProgram(final ProgramContext ctx) {
@@ -400,6 +401,12 @@ public class ColSyntaxVisitor extends ColBaseVisitor<Node> {
 
     @Override
     public Node visitFloatLiteral(FloatLiteralContext ctx) {
+        final var line = ctx.getStart().getLine();
+        final var column = ctx.getStart().getCharPositionInLine();
+        if (isValid(ctx.MALFORMED_FLOAT())) {
+            // A decimal point with digits on only one side; rejected in MalformedFloatSemanticsParser
+            return new MalformedFloatLiteral(line, column, ctx.getText());
+        }
         final Matcher matcher = FLOAT_PATTERN.matcher(ctx.getText().replace("_", ""));
         if (matcher.matches()) {
             final String normalizedNumber = normalizeFloatNumber(
@@ -410,8 +417,6 @@ public class ColSyntaxVisitor extends ColBaseVisitor<Node> {
                     "E"
             );
             final Type type = "f32".equals(matcher.group(6)) ? F32.INSTANCE : F64.INSTANCE;
-            final var line = ctx.getStart().getLine();
-            final var column = ctx.getStart().getCharPositionInLine();
             return new FloatLiteral(line, column, normalizedNumber, type);
         } else {
             throw new IllegalArgumentException("Input '" + ctx.getText().trim() + "' failed to match regexp");

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
@@ -231,28 +231,28 @@ public class ColSyntaxVisitor extends ColBaseVisitor<Node> {
             final var left = (Expression) ctx.relExpr().accept(this);
             final var right = (Expression) ctx.addExpr().accept(this);
 
-            final Expression relational;
+            final Expression re;
             if (isValid(ctx.EQ())) {
-                relational = new EqualExpression(line, column, left, right);
+                re = new EqualExpression(line, column, left, right);
             } else if (isValid(ctx.GE())) {
-                relational = new GreaterOrEqualExpression(line, column, left, right);
+                re = new GreaterOrEqualExpression(line, column, left, right);
             } else if (isValid(ctx.GT())) {
-                relational = new GreaterExpression(line, column, left, right);
+                re = new GreaterExpression(line, column, left, right);
             } else if (isValid(ctx.LE())) {
-                relational = new LessOrEqualExpression(line, column, left, right);
+                re = new LessOrEqualExpression(line, column, left, right);
             } else if (isValid(ctx.LT())) {
-                relational = new LessExpression(line, column, left, right);
+                re = new LessExpression(line, column, left, right);
             } else { // ctx.NE()
-                relational = new NotEqualExpression(line, column, left, right);
+                re = new NotEqualExpression(line, column, left, right);
             }
 
             // An unparenthesized chain (e.g. '1 < 2 < 3') has a relational production as its left
             // operand, while '(a == b) == c' descends through a parenthesized factor. Mark the chain
             // by parse shape so semantics can reject it without misjudging the latter.
             if (ctx.relExpr().getChildCount() > 1) {
-                return new ChainedRelationalExpression(line, column, relational);
+                return new ChainedRelationalExpression(line, column, re);
             }
-            return relational;
+            return re;
         }
     }
 

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
@@ -143,7 +143,9 @@ public class ColSyntaxVisitor extends ColBaseVisitor<Node> {
         final var name = ctx.ident().getText();
         final var type = isValid(ctx.type()) ? getType(ctx.type()) : null;
         final var expression = isValid(ctx.expr()) ? (Expression) ctx.expr().accept(this) : null;
-        return new ValDeclarationStatement(line, column, new DeclarationAssignment(line, column, name, type, expression));
+        // Binding with '=' instead of ':=' is reported in ValSemanticsParser
+        final var usesEquals = isValid(ctx.EQUALS());
+        return new ValDeclarationStatement(line, column, new DeclarationAssignment(line, column, name, type, expression), usesEquals);
     }
 
     @Override

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/compiler/ColSyntaxVisitor.java
@@ -20,6 +20,7 @@ package se.dykstrom.jcc.col.compiler;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import se.dykstrom.jcc.col.ast.expression.BecomeExpression;
+import se.dykstrom.jcc.col.ast.expression.ChainedRelationalExpression;
 import se.dykstrom.jcc.col.ast.statement.AliasStatement;
 import se.dykstrom.jcc.col.ast.statement.FunCallStatement;
 import se.dykstrom.jcc.col.ast.statement.ImportStatement;
@@ -204,22 +205,31 @@ public class ColSyntaxVisitor extends ColBaseVisitor<Node> {
         } else {
             final var line = ctx.getStart().getLine();
             final var column = ctx.getStart().getCharPositionInLine();
-            final var left = (Expression) ctx.addExpr(0).accept(this);
-            final var right = (Expression) ctx.addExpr(1).accept(this);
+            final var left = (Expression) ctx.relExpr().accept(this);
+            final var right = (Expression) ctx.addExpr().accept(this);
 
+            final Expression relational;
             if (isValid(ctx.EQ())) {
-                return new EqualExpression(line, column, left, right);
+                relational = new EqualExpression(line, column, left, right);
             } else if (isValid(ctx.GE())) {
-                return new GreaterOrEqualExpression(line, column, left, right);
+                relational = new GreaterOrEqualExpression(line, column, left, right);
             } else if (isValid(ctx.GT())) {
-                return new GreaterExpression(line, column, left, right);
+                relational = new GreaterExpression(line, column, left, right);
             } else if (isValid(ctx.LE())) {
-                return new LessOrEqualExpression(line, column, left, right);
+                relational = new LessOrEqualExpression(line, column, left, right);
             } else if (isValid(ctx.LT())) {
-                return new LessExpression(line, column, left, right);
+                relational = new LessExpression(line, column, left, right);
             } else { // ctx.NE()
-                return new NotEqualExpression(line, column, left, right);
+                relational = new NotEqualExpression(line, column, left, right);
             }
+
+            // An unparenthesized chain (e.g. '1 < 2 < 3') has a relational production as its left
+            // operand, while '(a == b) == c' descends through a parenthesized factor. Mark the chain
+            // by parse shape so semantics can reject it without misjudging the latter.
+            if (ctx.relExpr().getChildCount() > 1) {
+                return new ChainedRelationalExpression(line, column, relational);
+            }
+            return relational;
         }
     }
 

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/expression/ChainedRelationalSemanticsParser.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/expression/ChainedRelationalSemanticsParser.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Johan Dykstrom
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.dykstrom.jcc.col.semantics.expression;
+
+import se.dykstrom.jcc.col.ast.expression.ChainedRelationalExpression;
+import se.dykstrom.jcc.common.ast.Expression;
+import se.dykstrom.jcc.common.compiler.SemanticsParser;
+import se.dykstrom.jcc.common.compiler.TypeManager;
+import se.dykstrom.jcc.common.error.SemanticsException;
+import se.dykstrom.jcc.common.semantics.AbstractSemanticsParserComponent;
+import se.dykstrom.jcc.common.semantics.expression.ExpressionSemanticsParser;
+
+/**
+ * Rejects a relational expression synthesized from an unparenthesized chain, such as '1 &lt; 2 &lt; 3'.
+ * Relational operators are non-associative in COL; chaining them is almost always a mistake.
+ */
+public class ChainedRelationalSemanticsParser<T extends TypeManager> extends AbstractSemanticsParserComponent<T>
+        implements ExpressionSemanticsParser<ChainedRelationalExpression> {
+
+    public ChainedRelationalSemanticsParser(final SemanticsParser<T> semanticsParser) {
+        super(semanticsParser);
+    }
+
+    @Override
+    public Expression parse(final ChainedRelationalExpression expression) {
+        final var msg = "relational operators cannot be chained: write `1 < 2 and 2 < 3`";
+        reportError(expression, msg, new SemanticsException(msg));
+        return expression;
+    }
+}

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/expression/ChainedRelationalSemanticsParser.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/expression/ChainedRelationalSemanticsParser.java
@@ -38,7 +38,7 @@ public class ChainedRelationalSemanticsParser<T extends TypeManager> extends Abs
 
     @Override
     public Expression parse(final ChainedRelationalExpression expression) {
-        final var msg = "relational operators cannot be chained: write `1 < 2 and 2 < 3`";
+        final var msg = "relational operators cannot be chained: write '1 < 2 and 2 < 3'";
         reportError(expression, msg, new SemanticsException(msg));
         return expression;
     }

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/expression/MalformedFloatSemanticsParser.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/expression/MalformedFloatSemanticsParser.java
@@ -37,7 +37,7 @@ public class MalformedFloatSemanticsParser<T extends TypeManager> extends Abstra
 
     @Override
     public Expression parse(final MalformedFloatLiteral expression) {
-        final var msg = "a decimal point must have digits on both sides: write `0.99`";
+        final var msg = "a decimal point must have digits on both sides: write '0.99'";
         reportError(expression, msg, new SemanticsException(msg));
         return expression;
     }

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/expression/MalformedFloatSemanticsParser.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/expression/MalformedFloatSemanticsParser.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Johan Dykstrom
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.dykstrom.jcc.col.semantics.expression;
+
+import se.dykstrom.jcc.col.ast.expression.MalformedFloatLiteral;
+import se.dykstrom.jcc.common.ast.Expression;
+import se.dykstrom.jcc.common.compiler.SemanticsParser;
+import se.dykstrom.jcc.common.compiler.TypeManager;
+import se.dykstrom.jcc.common.error.SemanticsException;
+import se.dykstrom.jcc.common.semantics.AbstractSemanticsParserComponent;
+import se.dykstrom.jcc.common.semantics.expression.ExpressionSemanticsParser;
+
+/**
+ * Rejects a float literal written with a decimal point on only one side, such as '.99' or '17.'.
+ */
+public class MalformedFloatSemanticsParser<T extends TypeManager> extends AbstractSemanticsParserComponent<T>
+        implements ExpressionSemanticsParser<MalformedFloatLiteral> {
+
+    public MalformedFloatSemanticsParser(final SemanticsParser<T> semanticsParser) {
+        super(semanticsParser);
+    }
+
+    @Override
+    public Expression parse(final MalformedFloatLiteral expression) {
+        final var msg = "a decimal point must have digits on both sides: write `0.99`";
+        reportError(expression, msg, new SemanticsException(msg));
+        return expression;
+    }
+}

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/FunCallSemanticsParser.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/FunCallSemanticsParser.java
@@ -36,8 +36,8 @@ public class FunCallSemanticsParser<T extends TypeManager> extends AbstractSeman
     @Override
     public Statement parse(final FunCallStatement statement) {
         if (!statement.hasCall()) {
-            final var msg = "top-level function calls must be invoked with 'call': write `call " +
-                            statement.expression() + "`";
+            final var msg = "top-level function calls must be invoked with 'call': write 'call " +
+                            statement.expression() + "'";
             reportError(statement, msg, new SemanticsException(msg));
         }
         return statement.withExpression((FunctionCallExpression) parser.expression(statement.expression()));

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/FunCallSemanticsParser.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/FunCallSemanticsParser.java
@@ -22,6 +22,7 @@ import se.dykstrom.jcc.common.ast.FunctionCallExpression;
 import se.dykstrom.jcc.common.ast.Statement;
 import se.dykstrom.jcc.common.compiler.SemanticsParser;
 import se.dykstrom.jcc.common.compiler.TypeManager;
+import se.dykstrom.jcc.common.error.SemanticsException;
 import se.dykstrom.jcc.common.semantics.AbstractSemanticsParserComponent;
 import se.dykstrom.jcc.common.semantics.statement.StatementSemanticsParser;
 
@@ -34,6 +35,11 @@ public class FunCallSemanticsParser<T extends TypeManager> extends AbstractSeman
 
     @Override
     public Statement parse(final FunCallStatement statement) {
+        if (!statement.hasCall()) {
+            final var msg = "top-level function calls must be invoked with 'call': write `call " +
+                            statement.expression() + "`";
+            reportError(statement, msg, new SemanticsException(msg));
+        }
         return statement.withExpression((FunctionCallExpression) parser.expression(statement.expression()));
     }
 }

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/FunDefPass1SemanticsParser.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/FunDefPass1SemanticsParser.java
@@ -22,11 +22,13 @@ import se.dykstrom.jcc.common.ast.FunctionDefinitionStatement;
 import se.dykstrom.jcc.common.ast.Statement;
 import se.dykstrom.jcc.common.compiler.SemanticsParser;
 import se.dykstrom.jcc.common.compiler.TypeManager;
+import se.dykstrom.jcc.common.error.SemanticsException;
 import se.dykstrom.jcc.common.functions.UserDefinedFunction;
 import se.dykstrom.jcc.common.semantics.AbstractSemanticsParserComponent;
 import se.dykstrom.jcc.common.semantics.statement.StatementSemanticsParser;
 import se.dykstrom.jcc.common.types.Fun;
 import se.dykstrom.jcc.common.types.Type;
+import se.dykstrom.jcc.common.types.Void;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +51,13 @@ public class FunDefPass1SemanticsParser<T extends TypeManager> extends AbstractS
                                          .map(declaration -> resolveType(statement, declaration.type(), types()))
                                          .toList();
         final var returnType = resolveType(statement, functionType.getReturnType(), types());
+
+        // An omitted parameter type or return type is resolved to void; reject it with a message
+        // that names the rule, and skip defining a function with an incomplete signature.
+        if (!checkSignature(statement, declarations, argTypes, returnType)) {
+            return statement;
+        }
+
         final var function = new UserDefinedFunction(identifier.name(), argNames, argTypes, returnType);
 
         // Define function in symbol table
@@ -58,6 +67,27 @@ public class FunDefPass1SemanticsParser<T extends TypeManager> extends AbstractS
         final var updatedDeclarations = updateDeclarations(declarations, argTypes);
         return statement.withIdentifier(identifier.withType(updatedFunctionType))
                         .withDeclarations(updatedDeclarations);
+    }
+
+    private boolean checkSignature(final FunctionDefinitionStatement statement,
+                                   final List<Declaration> declarations,
+                                   final List<Type> argTypes,
+                                   final Type returnType) {
+        boolean complete = true;
+        for (int i = 0; i < declarations.size(); i++) {
+            if (argTypes.get(i) instanceof Void) {
+                final var name = declarations.get(i).name();
+                final var msg = "parameter '" + name + "' must declare a type";
+                reportError(statement, msg, new SemanticsException(msg));
+                complete = false;
+            }
+        }
+        if (returnType instanceof Void) {
+            final var msg = "function '" + statement.identifier().name() + "' must declare a return type";
+            reportError(statement, msg, new SemanticsException(msg));
+            complete = false;
+        }
+        return complete;
     }
 
     private List<Declaration> updateDeclarations(final List<Declaration> declarations, final List<Type> argTypes) {

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/FunDefPass1SemanticsParser.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/FunDefPass1SemanticsParser.java
@@ -54,7 +54,7 @@ public class FunDefPass1SemanticsParser<T extends TypeManager> extends AbstractS
 
         // An omitted parameter type or return type is resolved to void; reject it with a message
         // that names the rule, and skip defining a function with an incomplete signature.
-        if (!checkSignature(statement, declarations, argTypes, returnType)) {
+        if (!checkSignature(statement, argNames, argTypes, returnType)) {
             return statement;
         }
 
@@ -70,14 +70,13 @@ public class FunDefPass1SemanticsParser<T extends TypeManager> extends AbstractS
     }
 
     private boolean checkSignature(final FunctionDefinitionStatement statement,
-                                   final List<Declaration> declarations,
+                                   final List<String> argNames,
                                    final List<Type> argTypes,
                                    final Type returnType) {
         boolean complete = true;
-        for (int i = 0; i < declarations.size(); i++) {
+        for (int i = 0; i < argNames.size(); i++) {
             if (argTypes.get(i) instanceof Void) {
-                final var name = declarations.get(i).name();
-                final var msg = "parameter '" + name + "' must declare a type";
+                final var msg = "parameter '" + argNames.get(i) + "' must declare a type";
                 reportError(statement, msg, new SemanticsException(msg));
                 complete = false;
             }

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/ValSemanticsParser.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/ValSemanticsParser.java
@@ -30,6 +30,7 @@ import se.dykstrom.jcc.common.error.AmbiguousException;
 import se.dykstrom.jcc.common.error.DuplicateException;
 import se.dykstrom.jcc.common.error.InvalidTypeException;
 import se.dykstrom.jcc.common.error.InvalidValueException;
+import se.dykstrom.jcc.common.error.SemanticsException;
 import se.dykstrom.jcc.common.semantics.AbstractSemanticsParserComponent;
 import se.dykstrom.jcc.common.semantics.VariableUsageTracker;
 import se.dykstrom.jcc.common.semantics.statement.StatementSemanticsParser;
@@ -55,6 +56,8 @@ public class ValSemanticsParser<T extends TypeManager> extends AbstractSemantics
         final var declaration = statement.declaration();
         final var name = declaration.name();
 
+        checkBindOperator(statement, name);
+
         if (!checkInitializer(statement, declaration) || !checkName(statement, name)) {
             return statement;
         }
@@ -70,6 +73,14 @@ public class ValSemanticsParser<T extends TypeManager> extends AbstractSemantics
         usageTracker.declare(name, statement);
 
         return statement.withDeclaration(declaration.withType(type).withExpression(expression));
+    }
+
+    private void checkBindOperator(final ValDeclarationStatement statement, final String name) {
+        if (statement.usesEquals()) {
+            final var msg = "COL uses ':=' for binding: write `val " + name + " := " +
+                            statement.declaration().expression() + "`";
+            reportError(statement, msg, new SemanticsException(msg));
+        }
     }
 
     private boolean checkInitializer(final ValDeclarationStatement statement, final DeclarationAssignment declaration) {

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/ValSemanticsParser.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/ValSemanticsParser.java
@@ -77,8 +77,8 @@ public class ValSemanticsParser<T extends TypeManager> extends AbstractSemantics
 
     private void checkBindOperator(final ValDeclarationStatement statement, final String name) {
         if (statement.usesEquals()) {
-            final var msg = "COL uses ':=' for binding: write `val " + name + " := " +
-                            statement.declaration().expression() + "`";
+            final var msg = "COL uses ':=' for binding: write 'val " + name + " := " +
+                            statement.declaration().expression() + "'";
             reportError(statement, msg, new SemanticsException(msg));
         }
     }

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/AbstractColSemanticsParserTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/AbstractColSemanticsParserTests.kt
@@ -63,16 +63,26 @@ abstract class AbstractColSemanticsParserTests {
     }
 
     fun parseAndExpectError(text: String, errorText: String) {
+        parseAndExpectErrors(text, errorText)
+    }
+
+    /**
+     * Parses [text], asserting that semantic analysis fails and that every string in [errorTexts]
+     * appears in some reported error — used to pin multi-error reporting in a single compile.
+     */
+    fun parseAndExpectErrors(text: String, vararg errorTexts: String) {
         assertThrows<SemanticsException> {
             semanticsParser.parse(syntaxParser.parse(ByteArrayInputStream(text.toByteArray(StandardCharsets.UTF_8))))
         }
         assertTrue { errorListener.hasErrors() }
-        assertTrue(
-            errorListener.errors.any { it.msg.contains(errorText) },
-            "\nMissing: '$errorText'.\nFound:\n" + errorListener.errors.joinToString(
-                prefix = "'",
-                postfix = "'"
-            ) { it.msg } + "\n"
-        )
+        for (errorText in errorTexts) {
+            assertTrue(
+                errorListener.errors.any { it.msg.contains(errorText) },
+                "\nMissing: '$errorText'.\nFound:\n" + errorListener.errors.joinToString(
+                    prefix = "'",
+                    postfix = "'"
+                ) { it.msg } + "\n"
+            )
+        }
     }
 }

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserTests.kt
@@ -510,4 +510,9 @@ class ColSemanticsParserTests : AbstractColSemanticsParserTests() {
     fun shouldNotParseIfWithIncompatibleBranches() {
         parseAndExpectError("call println(if true then 0 else 1.0)", "both branches of an if expression must have the same type")
     }
+
+    @Test
+    fun shouldNotParseBareTopLevelCall() {
+        parseAndExpectError("println(7)", "top-level function calls must be invoked with 'call': write `call println(7)`")
+    }
 }

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserTests.kt
@@ -513,7 +513,7 @@ class ColSemanticsParserTests : AbstractColSemanticsParserTests() {
 
     @Test
     fun shouldNotParseBareTopLevelCall() {
-        parseAndExpectError("println(7)", "top-level function calls must be invoked with 'call': write `call println(7)`")
+        parseAndExpectError("println(7)", "top-level function calls must be invoked with 'call': write 'call println(7)'")
     }
 
     @Test
@@ -523,13 +523,13 @@ class ColSemanticsParserTests : AbstractColSemanticsParserTests() {
 
     @Test
     fun shouldNotParseChainedRelationalOperators() {
-        parseAndExpectError("call println(1 < 2 < 3)", "relational operators cannot be chained: write `1 < 2 and 2 < 3`")
+        parseAndExpectError("call println(1 < 2 < 3)", "relational operators cannot be chained: write '1 < 2 and 2 < 3'")
         parseAndExpectError("call println(1 == 2 == 3)", "relational operators cannot be chained")
     }
 
     @Test
     fun shouldNotParseFloatWithMissingDigits() {
-        parseAndExpectError("call println(.99)", "a decimal point must have digits on both sides: write `0.99`")
+        parseAndExpectError("call println(.99)", "a decimal point must have digits on both sides: write '0.99'")
         parseAndExpectError("call println(17.)", "a decimal point must have digits on both sides")
     }
 

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserTests.kt
@@ -520,4 +520,24 @@ class ColSemanticsParserTests : AbstractColSemanticsParserTests() {
     fun shouldNotParseIfExpressionWithoutElse() {
         parseAndExpectError("call println(if true then 1)", "if-expression requires an 'else' branch")
     }
+
+    @Test
+    fun shouldNotParseChainedRelationalOperators() {
+        parseAndExpectError("call println(1 < 2 < 3)", "relational operators cannot be chained: write `1 < 2 and 2 < 3`")
+        parseAndExpectError("call println(1 == 2 == 3)", "relational operators cannot be chained")
+    }
+
+    @Test
+    fun shouldReportSeveralIndependentErrorsInOneCompile() {
+        parseAndExpectErrors(
+            """
+            println(7)
+            call println(if true then 1)
+            call println(1 < 2 < 3)
+            """.trimIndent(),
+            "top-level function calls must be invoked with 'call'",
+            "if-expression requires an 'else' branch",
+            "relational operators cannot be chained"
+        )
+    }
 }

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserTests.kt
@@ -528,6 +528,12 @@ class ColSemanticsParserTests : AbstractColSemanticsParserTests() {
     }
 
     @Test
+    fun shouldNotParseFloatWithMissingDigits() {
+        parseAndExpectError("call println(.99)", "a decimal point must have digits on both sides: write `0.99`")
+        parseAndExpectError("call println(17.)", "a decimal point must have digits on both sides")
+    }
+
+    @Test
     fun shouldReportSeveralIndependentErrorsInOneCompile() {
         parseAndExpectErrors(
             """

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserTests.kt
@@ -515,4 +515,9 @@ class ColSemanticsParserTests : AbstractColSemanticsParserTests() {
     fun shouldNotParseBareTopLevelCall() {
         parseAndExpectError("println(7)", "top-level function calls must be invoked with 'call': write `call println(7)`")
     }
+
+    @Test
+    fun shouldNotParseIfExpressionWithoutElse() {
+        parseAndExpectError("call println(if true then 1)", "if-expression requires an 'else' branch")
+    }
 }

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserUserFunctionTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserUserFunctionTests.kt
@@ -521,4 +521,23 @@ class ColSemanticsParserUserFunctionTests : AbstractColSemanticsParserTests() {
             """
         )
     }
+
+    @Test
+    fun shouldNotParseFunctionWithoutReturnType() {
+        parseAndExpectError("fun f(x as i64) := x", "function 'f' must declare a return type")
+    }
+
+    @Test
+    fun shouldNotParseFunctionWithoutParameterType() {
+        parseAndExpectError("fun f(x) -> i64 := x", "parameter 'x' must declare a type")
+    }
+
+    @Test
+    fun shouldReportMissingReturnTypeAndParameterTypeTogether() {
+        parseAndExpectErrors(
+            "fun f(x, y as i64) := x",
+            "parameter 'x' must declare a type",
+            "function 'f' must declare a return type"
+        )
+    }
 }

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserValTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserValTests.kt
@@ -256,4 +256,15 @@ class ColSemanticsParserValTests : AbstractColSemanticsParserTests() {
     fun shouldNotParseValWithUndefinedType() {
         parseAndExpectError("val x as number := 17", "undefined type: number")
     }
+
+    @Test
+    fun shouldNotParseValBoundWithEquals() {
+        parseAndExpectError(
+            """
+            val x = 5
+            call println(x)
+            """.trimIndent(),
+            "COL uses ':=' for binding: write `val x := 5`"
+        )
+    }
 }

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserValTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserValTests.kt
@@ -264,7 +264,7 @@ class ColSemanticsParserValTests : AbstractColSemanticsParserTests() {
             val x = 5
             call println(x)
             """.trimIndent(),
-            "COL uses ':=' for binding: write `val x := 5`"
+            "COL uses ':=' for binding: write 'val x := 5'"
         )
     }
 }

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSyntaxParserTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSyntaxParserTests.kt
@@ -180,16 +180,25 @@ class ColSyntaxParserTests : AbstractColSyntaxParserTests() {
     }
 
     @Test
-    fun shouldNotParseFloatLiteralWithoutWholePart() {
-        // '.99' now lexes as a malformed-float token, rejected in semantics (see ColSemanticsParserTests)
+    fun shouldParseFloatLiteralWithoutWholePartAsMarker() {
+        // '.99' lexes as a malformed-float token; the error is caught in semantic analysis (see ColSemanticsParserTests)
         verify(parse("call println(.99)"), printlnCall(MalformedFloatLiteral(0, 0, ".99")))
+    }
+
+    @Test
+    fun shouldParseFloatLiteralWithoutFractionAsMarker() {
+        // '17.' lexes as a malformed-float token; the error is caught in semantic analysis (see ColSemanticsParserTests)
+        verify(parse("call println(17.)"), printlnCall(MalformedFloatLiteral(0, 0, "17.")))
+    }
+
+    @Test
+    fun shouldNotParseFloatLiteralWithoutWholePart() {
         // A trailing exponent still leaves a stray token, so this stays a syntax error
         assertThrows<SyntaxException> { parse("call println(.3E-10)") }
     }
 
     @Test
     fun shouldNotParseFloatLiteralWithoutFraction() {
-        verify(parse("call println(17.)"), printlnCall(MalformedFloatLiteral(0, 0, "17.")))
         assertThrows<SyntaxException> { parse("call println(17.E5)") }
     }
 

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSyntaxParserTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSyntaxParserTests.kt
@@ -18,6 +18,7 @@
 package se.dykstrom.jcc.col.compiler
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -76,6 +77,19 @@ class ColSyntaxParserTests : AbstractColSyntaxParserTests() {
     @Test
     fun shouldParsePrintlnAndComment() {
         verify(parse("call println() // comment"), printlnCall())
+    }
+
+    @Test
+    fun shouldParseCallWithCallKeyword() {
+        val statement = parse("call println(7)").statements[0] as FunCallStatement
+        assertTrue(statement.hasCall())
+    }
+
+    @Test
+    fun shouldParseBareCallWithoutCallKeyword() {
+        val statement = parse("println(7)").statements[0] as FunCallStatement
+        assertFalse(statement.hasCall())
+        assertEquals("println", statement.expression().identifier.name())
     }
 
     @Test

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSyntaxParserTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSyntaxParserTests.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.dykstrom.jcc.common.error.SyntaxException
+import se.dykstrom.jcc.col.ast.expression.MalformedFloatLiteral
 import se.dykstrom.jcc.col.ast.statement.AliasStatement
 import se.dykstrom.jcc.col.ast.statement.FunCallStatement
 import se.dykstrom.jcc.col.ColTests.Companion.FL_1_0
@@ -116,6 +117,19 @@ class ColSyntaxParserTests : AbstractColSyntaxParserTests() {
     }
 
     @Test
+    fun shouldParseUppercaseHexLiteral() {
+        verify(parse("call println(0xFE)"), printlnCall(IntegerLiteral(0, 0, "254", I64.INSTANCE)))
+        verify(parse("call println(0xff)"), printlnCall(IntegerLiteral(0, 0, "255", I64.INSTANCE)))
+    }
+
+    @Test
+    fun shouldParseLowercaseExponentLiteral() {
+        verify(parse("call println(1e9)"), printlnCall(FloatLiteral(0, 0, "1.0E+9", F64.INSTANCE)))
+        verify(parse("call println(1E9)"), printlnCall(FloatLiteral(0, 0, "1.0E+9", F64.INSTANCE)))
+        verify(parse("call println(1.5e-3)"), printlnCall(FloatLiteral(0, 0, "1.5E-3", F64.INSTANCE)))
+    }
+
+    @Test
     fun shouldParseIntegerLiteralsWithTypeSuffix() {
         verify(parse("call println(17i32)"), printlnCall(IL_17_I32))
         verify(parse("call println(17i64)"), printlnCall(IL_17))
@@ -167,13 +181,15 @@ class ColSyntaxParserTests : AbstractColSyntaxParserTests() {
 
     @Test
     fun shouldNotParseFloatLiteralWithoutWholePart() {
-        assertThrows<SyntaxException> { parse("call println(.99)") }
+        // '.99' now lexes as a malformed-float token, rejected in semantics (see ColSemanticsParserTests)
+        verify(parse("call println(.99)"), printlnCall(MalformedFloatLiteral(0, 0, ".99")))
+        // A trailing exponent still leaves a stray token, so this stays a syntax error
         assertThrows<SyntaxException> { parse("call println(.3E-10)") }
     }
 
     @Test
     fun shouldNotParseFloatLiteralWithoutFraction() {
-        assertThrows<SyntaxException> { parse("call println(17.)") }
+        verify(parse("call println(17.)"), printlnCall(MalformedFloatLiteral(0, 0, "17.")))
         assertThrows<SyntaxException> { parse("call println(17.E5)") }
     }
 

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSyntaxParserValTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSyntaxParserValTests.kt
@@ -17,6 +17,8 @@
 
 package se.dykstrom.jcc.col.compiler
 
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import se.dykstrom.jcc.col.ColTests.Companion.IL_17
 import se.dykstrom.jcc.col.ColTests.Companion.NT_I64
@@ -78,5 +80,14 @@ class ColSyntaxParserValTests : AbstractColSyntaxParserTests() {
         val expression = AddExpression(0, 0, IL_17, IntegerLiteral(0, 0, 1))
         val expected = ValDeclarationStatement(DeclarationAssignment("x", null, expression))
         verify(parse("val x := 17 + 1"), expected)
+    }
+
+    @Test
+    fun shouldParseValBoundWithEquals() {
+        // Binding with '=' parses; it is rejected as a semantic error (see ColSemanticsParserValTests)
+        val walrus = parse("val x := 5").statements[0] as ValDeclarationStatement
+        assertFalse(walrus.usesEquals())
+        val equals = parse("val x = 5").statements[0] as ValDeclarationStatement
+        assertTrue(equals.usesEquals())
     }
 }


### PR DESCRIPTION
Closes #56.

## What is this

COL encoded several language rules directly in the ANTLR grammar, so breaking one produced a generic parser error (`mismatched input`, `no viable alternative`, token-set dumps, an error pointing at EOF) and discarded the rest of the statement or file, hiding every later mistake. This reworks the six highest-impact cases (issue #56) to parse liberally and reject in semantic analysis, so each error names the broken rule and shows the fix.

## Approach

- **Bare top-level call:** `println(7)` parses; semantics asks for `call println(7)`.
- **If without else:** `ELSE expr` is optional; the missing branch is rejected in the shared `IfSemanticsParser`.
- **Chained relationals:** parsed left-associatively, then flagged by parse shape so `(a == b) == c` stays legal while `1 < 2 < 3` is rejected.
- **Number literals:** `0xFE` and `1e9` are now accepted; `.99` / `17.` lex as a marker and get a real message.
- **Signature omissions:** missing parameter `as type` or `-> returnType` resolve to void and are reported by name.
- **`=` for binding:** `=` is now a token, rejected in `ValSemanticsParser` in favour of `:=`.
- **Multi-error reporting:** because parses now succeed, items 1–3 report all of their errors in one compile.

## Updated context

- Docs: `docs/system/col-error-reporting.md` — new file recording the liberal-grammar / verify-in-semantics convention and its marker-node mechanism.
- Docs: `docs/system/col-language.md` — literal forms updated (hex either case, exponent `e`/`E`, the `.99`/`17.` rule now stated by the compiler).

## How to verify

Compile a snippet with each mistake and confirm the rule-naming message replaces the ANTLR output, e.g.:
`java -jar jcc-compiler/target/jcc-compiler-*.jar -S <file>.col` on `println(7)`, `call println(if true then 1)`, `call println(1 < 2 < 3)`, `call println(.99)`, `fun f(x) := x`, and `val x = 5`. A file combining the first three should report all three errors at once.
