### PR TITLE
Emit GC init call and IR stubs (issue #63 phase 2)

### DIFF
--- a/docs/system/code-generation.md
+++ b/docs/system/code-generation.md
@@ -76,6 +76,12 @@ In LLVM statement components, a dynamically allocated string that is consumed in
 
 Whether a value is such an owned temporary is decided by `LlvmUtils.allocatesTransientDynamicMemory`, used at every LLVM free site (`PrintCodeGenerator`, `FunctionCallCodeGenerator`'s argument cleanup and `become` guard, `BasicAddCodeGenerator`) — not the broader `MemoryManagementUtils.allocatesDynamicMemory`, which also matches user-defined function calls. A user-defined function may return a string it does not own (e.g. `DEF FNid$(x$) = x$` returns its argument, possibly a string-literal global), so freeing its result aborted at runtime; such results are instead leaked until the LLVM backend has a GC. New free sites must use the transient variant. The planned GC that will replace this leak/transient-free behavior is specified in `docs/GarbageCollection.md` and ADR 0003.
 
+## Garbage collector plumbing (LLVM, in progress)
+
+The LLVM GC is being built in phases (issue #63; design in `docs/GarbageCollection.md` and ADR 0003). As of phase 2 the backend knows the `jcc_gc_*` runtime API (`JccGcBuiltIns` in `jcc-llvm`, constants prefixed `GF_`) and emits `call void @jcc_gc_init(threshold, flags)` as the first statement of `main`, injected as a BASIC leading statement (`GC_INIT` / `GcInitStatement`) exactly like `INIT_COMMAND_LINE`. `threshold` is `-initial-gc-threshold`; `flags` carries the `JCC_GC_DEBUG` bit (1) when `-print-gc` is set.
+
+The runtime does not exist yet, so `AbstractLlvmCodeGenerator.generateDeclares` routes every called GC function to an in-module stub `define` (from `GcStubsGenerator`) instead of a `declare` — declaring and defining the same symbol is invalid IR. The stubs are no-ops (`jcc_gc_register` returns its argument) and, under `-print-gc`, log a fixed line via `puts`. GC functions are identified by the `FunctionUtils.LIB_JCC_GC` marker, which is only a routing tag: it does not name a real library (the GC ships in `libjccbas`, linked via the single `-l<stdlib>`). No roots, frames, or registration are emitted yet, and the transient-free/leak behavior above is unchanged. `GcStubsGenerator` and this stub routing are removed in phase 5 when the real `libjccbas` runtime lands.
+
 ## COL vals (LLVM)
 
 COL `val` declarations span semantics and codegen:

--- a/jcc-base/src/main/java/se/dykstrom/jcc/common/functions/LibraryFunction.java
+++ b/jcc-base/src/main/java/se/dykstrom/jcc/common/functions/LibraryFunction.java
@@ -73,6 +73,13 @@ public class LibraryFunction extends Function implements Comparable<LibraryFunct
     }
 
     /**
+     * Returns the file name of the library this function belongs to.
+     */
+    public String libraryFileName() {
+        return libraryFileName;
+    }
+
+    /**
      * Maps the given function name to the name to use in code generation.
      */
     public static String mapName(final String functionName) {

--- a/jcc-base/src/main/java/se/dykstrom/jcc/common/utils/FunctionUtils.java
+++ b/jcc-base/src/main/java/se/dykstrom/jcc/common/utils/FunctionUtils.java
@@ -28,6 +28,12 @@ public class FunctionUtils {
     public static final String LIB_JCC_BAS  = "libjccbas.dll";
     public static final String LIB_JCC_COL  = "libjcccol.a";
     public static final String LIB_LIBC     = "msvcrt.dll";
+    // Logical marker for the LLVM garbage collector runtime (jcc_gc_*). It only tags GC
+    // functions so the LLVM backend can route them to in-module stubs (phases 2-4) instead
+    // of ordinary declares; it does not drive linking (the LLVM backend links a single
+    // standard library, see LlvmAssembler). The GC symbols physically ship in libjccbas and
+    // are stubbed until the real runtime lands in phase 5 of issue #63.
+    public static final String LIB_JCC_GC   = "libjccgc";
 
     private FunctionUtils() { }
 }

--- a/jcc-basic/src/main/java/se/dykstrom/jcc/basic/ast/statement/GcInitStatement.java
+++ b/jcc-basic/src/main/java/se/dykstrom/jcc/basic/ast/statement/GcInitStatement.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Johan Dykstrom
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.dykstrom.jcc.basic.ast.statement;
+
+import se.dykstrom.jcc.common.ast.AbstractNode;
+import se.dykstrom.jcc.common.ast.Statement;
+
+/**
+ * Represents the call to the runtime function that initializes the garbage collector
+ * (jcc_gc_init). This statement is synthesized during LLVM code generation and inserted at
+ * the very start of the main function, before any string work happens; it is never produced
+ * by the parser. See issue #63 and {@code docs/GarbageCollection.md}.
+ *
+ * @author Johan Dykstrom
+ */
+public class GcInitStatement extends AbstractNode implements Statement {
+
+    public GcInitStatement(int line, int column) {
+        super(line, column);
+    }
+
+    @Override
+    public String toString() {
+        return "jcc_gc_init(threshold, flags)";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return GcInitStatement.class.hashCode();
+    }
+}

--- a/jcc-basic/src/main/java/se/dykstrom/jcc/basic/code/llvm/statement/GcInitCodeGenerator.java
+++ b/jcc-basic/src/main/java/se/dykstrom/jcc/basic/code/llvm/statement/GcInitCodeGenerator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Johan Dykstrom
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.dykstrom.jcc.basic.code.llvm.statement;
+
+import se.dykstrom.jcc.basic.ast.statement.GcInitStatement;
+import se.dykstrom.jcc.common.code.Line;
+import se.dykstrom.jcc.common.symbols.SymbolTable;
+import se.dykstrom.jcc.common.types.I64;
+import se.dykstrom.jcc.common.utils.GcOptions;
+import se.dykstrom.jcc.llvm.code.LlvmCodeGenerator;
+import se.dykstrom.jcc.llvm.code.statement.LlvmStatementCodeGenerator;
+import se.dykstrom.jcc.llvm.operand.LiteralOperand;
+import se.dykstrom.jcc.llvm.operand.LlvmOperand;
+import se.dykstrom.jcc.llvm.operation.CallOperation;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static se.dykstrom.jcc.llvm.code.JccGcBuiltIns.GF_INIT;
+
+/**
+ * Generates the call that initializes the garbage collector at the start of main:
+ * {@code call void @jcc_gc_init(i64 <threshold>, i64 <flags>)}. The arguments come from the
+ * command-line GC options (shared with the FASM backend):
+ * <ul>
+ *   <li>{@code threshold} is {@code -initial-gc-threshold} (the runtime treats a
+ *       non-positive value as "use the default");</li>
+ *   <li>{@code flags} carries the {@code JCC_GC_DEBUG} bit (value 1) when {@code -print-gc}
+ *       was given, and is 0 otherwise.</li>
+ * </ul>
+ *
+ * @author Johan Dykstrom
+ */
+public record GcInitCodeGenerator(LlvmCodeGenerator codeGenerator)
+        implements LlvmStatementCodeGenerator<GcInitStatement> {
+
+    /** The JCC_GC_DEBUG flag, matching the value defined in jcc_gc.h. */
+    private static final long JCC_GC_DEBUG = 1L;
+
+    public GcInitCodeGenerator {
+        requireNonNull(codeGenerator);
+    }
+
+    @Override
+    public void toLlvm(final GcInitStatement statement, final List<Line> lines, final SymbolTable symbolTable) {
+        final long threshold = GcOptions.INSTANCE.getInitialGcThreshold();
+        final long flags = GcOptions.INSTANCE.isPrintGc() ? JCC_GC_DEBUG : 0L;
+
+        final LlvmOperand opThreshold = new LiteralOperand(threshold, I64.INSTANCE);
+        final LlvmOperand opFlags = new LiteralOperand(flags, I64.INSTANCE);
+        lines.add(new CallOperation(null, GF_INIT, List.of(opThreshold, opFlags)));
+    }
+}

--- a/jcc-basic/src/main/java/se/dykstrom/jcc/basic/compiler/BasicLlvmCodeGenerator.java
+++ b/jcc-basic/src/main/java/se/dykstrom/jcc/basic/compiler/BasicLlvmCodeGenerator.java
@@ -58,6 +58,12 @@ public class BasicLlvmCodeGenerator extends AbstractLlvmCodeGenerator {
      */
     protected static final Statement INIT_COMMAND_LINE = new InitCommandLineStatement(0, 0);
 
+    /**
+     * A statement that initializes the garbage collector, for use as the first leading statement
+     * in main so the collector is live before any string work happens (issue #63).
+     */
+    protected static final Statement GC_INIT = new GcInitStatement(0, 0);
+
     private final List<Label> possibleReturnTargets = new ArrayList<>();
     // Counter for generating unique `after.gosub.*` labels. Reset at the start of
     // each `generate(...)` invocation so labels are unique per generated module.
@@ -114,9 +120,9 @@ public class BasicLlvmCodeGenerator extends AbstractLlvmCodeGenerator {
                     new Declaration(InitCommandLineCodeGenerator.ARGC, I32.INSTANCE),
                     new Declaration(InitCommandLineCodeGenerator.ARGV, Ptr.INSTANCE)
             );
-            mainFunction = generateMainFunction(statements, parameters, List.of(INIT_COMMAND_LINE), List.of(RETURN_I32_ZERO));
+            mainFunction = generateMainFunction(statements, parameters, List.of(GC_INIT, INIT_COMMAND_LINE), List.of(RETURN_I32_ZERO));
         } else {
-            mainFunction = generateMainFunction(statements, List.of(RETURN_I32_ZERO));
+            mainFunction = generateMainFunction(statements, List.of(), List.of(GC_INIT), List.of(RETURN_I32_ZERO));
         }
         // Generate code for main function
         statement(mainFunction, lines, symbolTable());
@@ -253,13 +259,12 @@ public class BasicLlvmCodeGenerator extends AbstractLlvmCodeGenerator {
 
     private static boolean referencesCommand(final Expression expression) {
         return switch (expression) {
-            case null -> false;
             case FunctionCallExpression e -> e.getIdentifier().name().equals(BasicSymbols.BF_COMMAND.getName())
                     || e.getArgs().stream().anyMatch(BasicLlvmCodeGenerator::referencesCommand);
             case BinaryExpression e -> referencesCommand(e.getLeft()) || referencesCommand(e.getRight());
             case UnaryExpression e -> referencesCommand(e.getExpression());
             case ArrayAccessExpression e -> e.getSubscripts().stream().anyMatch(BasicLlvmCodeGenerator::referencesCommand);
-            default -> false;
+            case null, default -> false;
         };
     }
 
@@ -281,6 +286,7 @@ public class BasicLlvmCodeGenerator extends AbstractLlvmCodeGenerator {
         map.put(DefIntStatement.class, new DefTypeCodeGenerator());
         map.put(DefStrStatement.class, new DefTypeCodeGenerator());
         map.put(EndStatement.class, new EndCodeGenerator());
+        map.put(GcInitStatement.class, new GcInitCodeGenerator(this));
         map.put(GosubStatement.class, new GosubCodeGenerator());
         map.put(IDivAssignStatement.class, new IDivAssignCodeGenerator(this, GLOBAL));
         map.put(IncStatement.class, new IncCodeGenerator(this, GLOBAL));

--- a/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicLlvmCodeGeneratorGcTests.kt
+++ b/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicLlvmCodeGeneratorGcTests.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 Johan Dykstrom
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.dykstrom.jcc.basic.compiler
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import se.dykstrom.jcc.common.utils.GcOptions
+
+/**
+ * Tests the garbage-collector plumbing emitted by the LLVM backend (issue #63 phase 2):
+ * the jcc_gc_init call injected at the start of main, and the temporary in-module stub
+ * definitions that stand in for the not-yet-existing runtime. Only jcc_gc_init is emitted in
+ * this phase; roots, frames, and registration arrive in later phases.
+ *
+ * These are IR-only tests (no clang). The GC options are a JVM-wide singleton, so each test
+ * sets them explicitly and the original values are restored afterwards.
+ */
+internal class BasicLlvmCodeGeneratorGcTests : AbstractBasicCodeGeneratorTests() {
+
+    private val cg = BasicLlvmCodeGenerator(typeManager, symbols, optimizer)
+
+    private var savedPrintGc = false
+    private var savedThreshold = 0
+
+    @BeforeEach
+    fun setUp() {
+        savedPrintGc = GcOptions.INSTANCE.isPrintGc
+        savedThreshold = GcOptions.INSTANCE.initialGcThreshold
+    }
+
+    @AfterEach
+    fun tearDown() {
+        GcOptions.INSTANCE.isPrintGc = savedPrintGc
+        GcOptions.INSTANCE.initialGcThreshold = savedThreshold
+    }
+
+    @Test
+    fun shouldInitializeGcAtStartOfMain() {
+        GcOptions.INSTANCE.isPrintGc = false
+        GcOptions.INSTANCE.initialGcThreshold = 100
+
+        val result = assembleProgram(cg, emptyList())
+
+        // jcc_gc_init is called first in main, with the threshold and flags=0 (debug off)
+        assertContains(result, listOf(
+            "entry:",
+            "call void @jcc_gc_init(i64 100, i64 0)",
+        ))
+        // The runtime does not exist yet, so jcc_gc_init is given a stub definition, not a declare
+        assertContains(result, listOf("define void @jcc_gc_init(i64 %0, i64 %1) {"))
+        assertNotContains(result, listOf("declare void @jcc_gc_init"))
+    }
+
+    @Test
+    fun shouldPassThresholdFromOptions() {
+        GcOptions.INSTANCE.isPrintGc = false
+        GcOptions.INSTANCE.initialGcThreshold = 5
+
+        val result = assembleProgram(cg, emptyList())
+
+        assertContains(result, listOf("call void @jcc_gc_init(i64 5, i64 0)"))
+    }
+
+    @Test
+    fun shouldEnableDebugFlagAndLogFromStubWhenPrintGc() {
+        GcOptions.INSTANCE.isPrintGc = true
+        GcOptions.INSTANCE.initialGcThreshold = 100
+
+        val result = assembleProgram(cg, emptyList())
+
+        // The JCC_GC_DEBUG flag (1) is passed to jcc_gc_init
+        assertContains(result, listOf("call void @jcc_gc_init(i64 100, i64 1)"))
+        // The stub logs a fixed message via puts
+        assertContains(result, listOf(
+            "declare i32 @puts(ptr)",
+            "@.str.gc.init = private constant [18 x i8] c\"jcc_gc: stub init\\00\"",
+            "call i32 @puts(ptr @.str.gc.init)",
+        ))
+    }
+
+    @Test
+    fun shouldNotLogFromStubWhenNotPrintGc() {
+        GcOptions.INSTANCE.isPrintGc = false
+        GcOptions.INSTANCE.initialGcThreshold = 100
+
+        val result = assembleProgram(cg, emptyList())
+
+        assertNotContains(result, listOf("@puts", "jcc_gc: stub"))
+    }
+
+    @Test
+    fun shouldNotEmitRootsFramesOrRegistrationYet() {
+        // Phase 2 keeps semantics unchanged: no roots, frames, or registration are emitted;
+        // those belong to phases 3 and 4.
+        GcOptions.INSTANCE.isPrintGc = false
+        GcOptions.INSTANCE.initialGcThreshold = 100
+
+        val result = assembleProgram(cg, emptyList())
+
+        assertNotContains(result, listOf(
+            "jcc_gc_push_frame",
+            "jcc_gc_pop_frame",
+            "jcc_gc_add_root",
+            "jcc_gc_register",
+            "jcc_gc_set_global_roots",
+        ))
+    }
+}

--- a/jcc-llvm/src/main/java/se/dykstrom/jcc/llvm/code/AbstractLlvmCodeGenerator.java
+++ b/jcc-llvm/src/main/java/se/dykstrom/jcc/llvm/code/AbstractLlvmCodeGenerator.java
@@ -24,6 +24,7 @@ import se.dykstrom.jcc.common.compiler.TypeManager;
 import se.dykstrom.jcc.common.functions.LibraryFunction;
 import se.dykstrom.jcc.common.optimization.AstOptimizer;
 import se.dykstrom.jcc.common.symbols.SymbolTable;
+import se.dykstrom.jcc.common.utils.GcOptions;
 import se.dykstrom.jcc.common.types.Arr;
 import se.dykstrom.jcc.common.types.Fun;
 import se.dykstrom.jcc.common.types.I32;
@@ -42,6 +43,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 import static se.dykstrom.jcc.common.ast.IntegerLiteral.ZERO_I32;
 import static se.dykstrom.jcc.common.utils.ExpressionUtils.evaluateIntegerExpressions;
+import static se.dykstrom.jcc.common.utils.FunctionUtils.LIB_JCC_GC;
 import static se.dykstrom.jcc.llvm.LlvmOperator.*;
 import static se.dykstrom.jcc.common.symbols.Scope.NONE;
 
@@ -148,12 +150,31 @@ public abstract class AbstractLlvmCodeGenerator implements LlvmCodeGenerator {
         );
     }
 
-    protected List<? extends LlvmOperation> generateDeclares(final Set<LibraryFunction> calledFunctions) {
-        // Add a declare operation for each called library function
-        return calledFunctions.stream()
+    protected List<? extends Line> generateDeclares(final Set<LibraryFunction> calledFunctions) {
+        // Partition the called library functions into GC runtime functions and the rest.
+        // The GC functions have no real implementation yet (issue #63 phase 2-4), so instead
+        // of declaring them they are given temporary in-module stub definitions - declaring
+        // AND defining the same symbol would be invalid IR. Ordinary library functions get a
+        // plain declare. This is a no-op for languages that call no GC functions.
+        final var gcFunctions = calledFunctions.stream()
+                .filter(AbstractLlvmCodeGenerator::isGcFunction)
+                .collect(toSet());
+
+        final var lines = new ArrayList<Line>();
+        // Add a declare operation for each called non-GC library function
+        calledFunctions.stream()
+                .filter(f -> !isGcFunction(f))
                 .sorted()
                 .map(DeclareOperation::new)
-                .toList();
+                .forEach(lines::add);
+        // Add temporary stub definitions for the called GC functions
+        lines.addAll(GcStubsGenerator.generateStubs(gcFunctions, GcOptions.INSTANCE.isPrintGc()));
+        return lines;
+    }
+
+    /** Returns true if the given library function is part of the GC runtime (jcc_gc_*). */
+    private static boolean isGcFunction(final LibraryFunction function) {
+        return LIB_JCC_GC.equals(function.libraryFileName());
     }
 
     protected Set<LibraryFunction> getCalledFunctions(final List<Line> operations) {

--- a/jcc-llvm/src/main/java/se/dykstrom/jcc/llvm/code/GcStubsGenerator.java
+++ b/jcc-llvm/src/main/java/se/dykstrom/jcc/llvm/code/GcStubsGenerator.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2026 Johan Dykstrom
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.dykstrom.jcc.llvm.code;
+
+import se.dykstrom.jcc.common.code.Line;
+import se.dykstrom.jcc.common.code.Text;
+import se.dykstrom.jcc.common.functions.LibraryFunction;
+import se.dykstrom.jcc.common.types.Ptr;
+import se.dykstrom.jcc.llvm.LlvmComment;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Generates temporary, in-module definitions ("stubs") of the {@code jcc_gc_*} runtime
+ * functions the program calls. This is scaffolding for issue #63 phases 2-4: the compiler
+ * emits calls into the collector before the real runtime (in {@code libjccbas}) exists, so
+ * the generated IR must still define those symbols to link and run. The stubs are pure
+ * no-ops with the correct signatures:
+ * <ul>
+ *   <li>{@code jcc_gc_register} / {@code jcc_gc_register_object} return their first argument
+ *       unchanged (the ownership-transfer identity), so registration is a pass-through.</li>
+ *   <li>every other GC function returns void.</li>
+ * </ul>
+ * They therefore never collect anything - programs leak, but behave correctly - which is the
+ * intended state until phase 5 replaces these stubs with ordinary {@code declare}s of the
+ * real runtime symbols. THIS WHOLE CLASS IS DELETED IN PHASE 5.
+ * <p>
+ * When GC debug output is requested ({@code -print-gc}), each stub body logs a fixed line
+ * such as {@code jcc_gc: stub init} via {@code puts}. {@code puts} is used deliberately: JCC
+ * never emits it otherwise, so declaring it here cannot clash with a {@code printf}
+ * declaration generated elsewhere. The log lines let phase 4 integration tests observe that
+ * the GC calls are wired up.
+ */
+public final class GcStubsGenerator {
+
+    private GcStubsGenerator() { }
+
+    /**
+     * Generates stub definitions for the given called GC functions. LLVM IR is not
+     * order-sensitive across globals/declares/definitions, so the returned lines (a
+     * {@code puts} declaration and message-string globals when {@code printGc} is set,
+     * followed by the stub definitions) can be spliced in wherever declares are emitted.
+     *
+     * @param gcFunctions The GC library functions actually called by the program.
+     * @param printGc     Whether {@code -print-gc} was given, enabling per-stub logging.
+     * @return The lines defining the stubs, or an empty list if no GC function is called.
+     */
+    public static List<Line> generateStubs(final Collection<LibraryFunction> gcFunctions, final boolean printGc) {
+        if (gcFunctions.isEmpty()) {
+            return List.of();
+        }
+
+        // Sort by external name so the output is deterministic (matches generateDeclares).
+        final var sorted = gcFunctions.stream().sorted().toList();
+
+        final var lines = new ArrayList<Line>();
+        lines.add(new LlvmComment("--- Temporary GC runtime stubs (issue #63); removed in phase 5 ---"));
+
+        if (printGc) {
+            // puts is safe to declare here: JCC never emits it otherwise, so there is no
+            // risk of a duplicate declaration clashing with printf.
+            lines.add(new Text("declare i32 @puts(ptr)"));
+            sorted.forEach(f -> lines.add(new Text(messageGlobal(f))));
+        }
+
+        for (final var function : sorted) {
+            lines.addAll(stubDefinition(function, printGc));
+            lines.add(new Text(""));
+        }
+
+        return lines;
+    }
+
+    /**
+     * Builds the definition of a single stub function, e.g.
+     * <pre>
+     * define void @jcc_gc_init(i64 %0, i64 %1) {
+     * ret void
+     * }
+     * </pre>
+     */
+    private static List<Line> stubDefinition(final LibraryFunction function, final boolean printGc) {
+        final var lines = new ArrayList<Line>();
+
+        final var argTypes = function.getArgTypes();
+        final var params = new StringBuilder();
+        for (int i = 0; i < argTypes.size(); i++) {
+            if (i > 0) {
+                params.append(", ");
+            }
+            params.append(argTypes.get(i).llvmName()).append(" %").append(i);
+        }
+
+        lines.add(new Text("define " + function.getReturnType().llvmName() +
+                           " @" + function.externalName() + "(" + params + ") {"));
+        if (printGc) {
+            lines.add(new Text("call i32 @puts(ptr @" + messageGlobalName(function) + ")"));
+        }
+        // register / register_object are the only pointer-returning GC functions; they return
+        // their first argument unchanged (ownership transfer is a no-op in the stub). Every
+        // other GC function returns void.
+        if (function.getReturnType() instanceof Ptr) {
+            lines.add(new Text("ret ptr %0"));
+        } else {
+            lines.add(new Text("ret void"));
+        }
+        lines.add(new Text("}"));
+
+        return lines;
+    }
+
+    /** Renders the private constant holding a stub's log message, e.g. {@code jcc_gc: stub init}. */
+    private static String messageGlobal(final LibraryFunction function) {
+        final var message = "jcc_gc: stub " + shortName(function);
+        // + 1 for the trailing NUL required by puts.
+        final var length = message.getBytes(UTF_8).length + 1;
+        return "@" + messageGlobalName(function) + " = private constant [" + length + " x i8] c\"" + message + "\\00\"";
+    }
+
+    private static String messageGlobalName(final LibraryFunction function) {
+        return ".str.gc." + shortName(function);
+    }
+
+    /** The GC function name without the {@code jcc_gc_} prefix, e.g. {@code init}, {@code register}. */
+    private static String shortName(final LibraryFunction function) {
+        return function.externalName().replaceFirst("^jcc_gc_", "");
+    }
+}

--- a/jcc-llvm/src/main/java/se/dykstrom/jcc/llvm/code/JccGcBuiltIns.java
+++ b/jcc-llvm/src/main/java/se/dykstrom/jcc/llvm/code/JccGcBuiltIns.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Johan Dykstrom
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.dykstrom.jcc.llvm.code;
+
+import se.dykstrom.jcc.common.functions.ExternalFunction;
+import se.dykstrom.jcc.common.functions.Function;
+import se.dykstrom.jcc.common.functions.LibraryFunction;
+import se.dykstrom.jcc.common.types.I64;
+import se.dykstrom.jcc.common.types.Ptr;
+import se.dykstrom.jcc.common.types.Type;
+import se.dykstrom.jcc.common.types.Void;
+
+import java.util.List;
+
+import static se.dykstrom.jcc.common.utils.FunctionUtils.LIB_JCC_GC;
+
+/**
+ * Defines the runtime garbage collector API (the {@code jcc_gc_*} functions) as library
+ * functions, so the LLVM backend can emit calls into the collector. The API and its
+ * semantics are specified in {@code docs/GarbageCollection.md} (issue #63).
+ * <p>
+ * This class is language-agnostic and lives in the LLVM module so every language that
+ * targets LLVM (BASIC now, COL later) can reuse it. The functions are tagged with the
+ * {@link se.dykstrom.jcc.common.utils.FunctionUtils#LIB_JCC_GC} library marker, which lets
+ * {@link AbstractLlvmCodeGenerator} route them to in-module stubs until the real runtime
+ * exists (see {@link GcStubsGenerator}).
+ * <p>
+ * The full API surface is declared here so later phases can reuse it; phase 2 only emits
+ * {@link #GF_INIT}. GC function constants are prefixed with the string "GF".
+ */
+public final class JccGcBuiltIns {
+
+    /** {@code void jcc_gc_init(i64 initial_threshold, i64 flags)} - initialize the collector. */
+    public static final Function GF_INIT =
+            create(".gc_init", List.of(I64.INSTANCE, I64.INSTANCE), Void.INSTANCE, "jcc_gc_init");
+
+    /** {@code void jcc_gc_set_global_roots(ptr ranges)} - register the global root table. */
+    public static final Function GF_SET_GLOBAL_ROOTS =
+            create(".gc_set_global_roots", List.of(Ptr.INSTANCE), Void.INSTANCE, "jcc_gc_set_global_roots");
+
+    /** {@code void jcc_gc_push_frame(void)} - open a shadow-stack frame on function entry. */
+    public static final Function GF_PUSH_FRAME =
+            create(".gc_push_frame", List.of(), Void.INSTANCE, "jcc_gc_push_frame");
+
+    /** {@code void jcc_gc_pop_frame(void)} - close the current shadow-stack frame. */
+    public static final Function GF_POP_FRAME =
+            create(".gc_pop_frame", List.of(), Void.INSTANCE, "jcc_gc_pop_frame");
+
+    /** {@code void jcc_gc_add_root(ptr slot)} - add a pointer slot to the current frame. */
+    public static final Function GF_ADD_ROOT =
+            create(".gc_add_root", List.of(Ptr.INSTANCE), Void.INSTANCE, "jcc_gc_add_root");
+
+    /** {@code ptr jcc_gc_register(ptr p)} - transfer ownership of p to the GC and return p. */
+    public static final Function GF_REGISTER =
+            create(".gc_register", List.of(Ptr.INSTANCE), Ptr.INSTANCE, "jcc_gc_register");
+
+    /** {@code ptr jcc_gc_register_object(ptr p, ptr type)} - as register, with a type descriptor. */
+    public static final Function GF_REGISTER_OBJECT =
+            create(".gc_register_object", List.of(Ptr.INSTANCE, Ptr.INSTANCE), Ptr.INSTANCE, "jcc_gc_register_object");
+
+    /** {@code void jcc_gc_collect(void)} - run a full mark-sweep collection now. */
+    public static final Function GF_COLLECT =
+            create(".gc_collect", List.of(), Void.INSTANCE, "jcc_gc_collect");
+
+    private static LibraryFunction create(final String name,
+                                          final List<Type> argTypes,
+                                          final Type returnType,
+                                          final String externalName) {
+        return new LibraryFunction(name, argTypes, returnType, LIB_JCC_GC, new ExternalFunction(externalName));
+    }
+
+    private JccGcBuiltIns() { }
+}


### PR DESCRIPTION
## What

Phase 2 of the LLVM garbage collector (issue #63). Teaches the LLVM backend the `jcc_gc_*` runtime API and emits `jcc_gc_init(threshold, flags)` at the start of `main`. Because the real runtime does not exist yet (phase 5), called GC functions get temporary in-module stub definitions so the generated IR still links and runs.

Semantics are unchanged: the existing eager frees stay in place, no roots/frames/registration are emitted, and programs behave identically. This is the first code phase; phase 1 (ADR 0003 + `docs/GarbageCollection.md`) was spec-only.

## Approach

- New `JccGcBuiltIns` (jcc-llvm) declares the full `jcc_gc_*` API as `LibraryFunction` constants (prefix `GF_`), tagged with a new `FunctionUtils.LIB_JCC_GC` marker. Only `jcc_gc_init` is emitted this phase; the rest exist for phases 3–4.
- `GcStubsGenerator` (jcc-llvm) emits in-module no-op stub `define`s for the called GC functions — `jcc_gc_register` returns its argument, everything else returns void. Under `-print-gc` each stub logs a fixed line via `puts`. This whole class is deleted in phase 5.
- `AbstractLlvmCodeGenerator.generateDeclares` now partitions called library functions by the `LIB_JCC_GC` marker: ordinary functions get a `declare`, GC functions get a stub `define` (declaring and defining the same symbol is invalid IR). No-op for languages that call no GC functions.
- The `jcc_gc_init` call is injected as a BASIC leading statement (`GcInitStatement` / `GcInitCodeGenerator`), mirroring the existing `INIT_COMMAND_LINE`, so Tiny/Assembunny/COL are untouched. The reusable GC pieces live in jcc-llvm so COL can adopt them in phase 7.

Verified: 67 BASIC LLVM codegen unit tests (incl. 5 new GC tests) pass; `BasicLlvmCompileAndRunIT` (37 tests) passes — the stubbed IR links via clang and runs correctly at `-O0` and `-O2`. FASM backend untouched.

## Updated context

`docs/system/code-generation.md` gains a "Garbage collector plumbing (LLVM, in progress)" section recording the current emission state and the `LIB_JCC_GC` routing marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)