### PR TITLE
Document the final LLVM GC state and close out issue #63 phase 8

### DIFF
--- a/docs/Arrays.md
+++ b/docs/Arrays.md
@@ -41,6 +41,10 @@ array.
 
 ## Garbage Collection
 
+This section describes the **FASM** backend's model. The LLVM backend roots array string
+elements differently — through a global-roots range — as described in the LLVM note at the
+end of this document and in `docs/system/code-generation.md`.
+
 
 ### Array Elements
 
@@ -205,7 +209,9 @@ runtime call: it affects only the array lower bound, which is a compile-time con
   `d - 1` (the 1-based dimension `d` defaults to 1). A runtime dimension argument is therefore
   supported directly.
 
-Arrays remain static (created at program start, live until exit). Garbage collection of string
-elements is not yet implemented on the LLVM backend — string elements are stored and read/written
-but not collected, consistent with how scalar dynamic strings currently behave there. See the
-"Dynamic string memory (LLVM)" note in `docs/system/code-generation.md`.
+Arrays remain static (created at program start, live until exit). On the LLVM backend their
+string elements are garbage-collected: a string stored into an element is registered with the
+collector, and the array's whole element region is a GC root — a single range in the
+`@jcc.gc.global.roots` table. So a retained element survives every collection, while a string it
+replaces becomes unreachable and is reclaimed on the next cycle. See the "Garbage collector
+plumbing (LLVM)" and "Dynamic string memory (LLVM)" notes in `docs/system/code-generation.md`.

--- a/docs/GarbageCollection.md
+++ b/docs/GarbageCollection.md
@@ -441,17 +441,23 @@ the focus on use-after-free and double-free.
 
 ## Status
 
-The collector is the intended memory-management model for the LLVM backend and is
-being built in the phases laid out in GitHub issue #63. This document and
-[ADR 0003](adr/0003-llvm-gc-shadow-stack.md) are the first phase: the architecture
-decision and the API specification, published so the compiler plumbing and the
-`libjccbas` runtime can be built against a fixed contract.
+The collector is the memory-management model for the LLVM backend, delivered across the
+phases of GitHub issue #63. This document and [ADR 0003](adr/0003-llvm-gc-shadow-stack.md)
+are the architecture decision and API specification; the compiler plumbing and the
+`libjccbas` runtime were built against that fixed contract.
 
-The compiler plumbing and the `libjccbas` runtime are both in place: the LLVM
-backend registers every dynamic string with the collector and links against the
-real runtime in `libjccbas` 2.2.0 (see `docs/system/code-generation.md`,
-"Dynamic string memory (LLVM)"). The `jcc_gc.h` header below is the API of record
-in this repository; the canonical copy lives in the `libjccbas` runtime (2.2.0).
+Everything is in place. The LLVM backend registers every dynamic string — scalars, string
+array elements, concatenation results, and library results — with the collector, emits the
+shadow-stack frames and roots, and links against the real runtime in `libjccbas` 2.2.0 (see
+`docs/system/code-generation.md`, "Dynamic string memory (LLVM)" and "Garbage collector
+plumbing (LLVM)"). Guaranteed tail calls pop their frame before the `musttail` call, so the
+collector is correct across `become` too. The `jcc_gc.h` header below is the API of record in
+this repository; the canonical copy lives in the `libjccbas` runtime (2.2.0).
+
+The one deferred follow-up is COL string/closure enablement: when COL grows heap types it will
+vendor `jcc_gc.[ch]` and add its string functions to `LibJccColBuiltIns`. By construction that
+needs no jcc-llvm changes — a language opts in purely by wiring `RuntimeGcCodeGenerator`
+(requirement 7).
 
 
 ## Appendix: `jcc_gc.h`

--- a/docs/system/standard-libraries.md
+++ b/docs/system/standard-libraries.md
@@ -90,6 +90,12 @@ Wire it into jcc (worked example: `millis` in COL):
    each backend you intend to support — `millis` is wired only into the LLVM backend.
 4. Cover the new function with tests, mirroring the existing `*Functions`/codegen tests.
 
+**Memory ownership (`Str` results).** On the LLVM backend a `Str`-returning function's result
+is passed to `jcc_gc_register`, which takes ownership of the pointer and eventually `free()`s
+it. Such a function must return a freshly heap-allocated block — never a pointer into
+static/read-only memory, a caller-supplied buffer, or a shared cache — or the collector will
+free memory it does not own. See the fresh-block contract in `docs/GarbageCollection.md`.
+
 ### Math built-ins: LLVM intrinsics and direct libm
 
 COL's math built-ins do not go through the JCC runtime library. Their backend


### PR DESCRIPTION
## What is this
Phase 8 (docs and closure) of the issue #63 LLVM garbage collector. Brings the durable docs in line with the collector that shipped in phases 1–7 — no code change.

## Approach
- **Correct the stale Arrays.md note:** LLVM string array elements ARE garbage-collected (registered on store, rooted as a global-roots range), reclaimed when overwritten — the old note said "not yet implemented".
- **Tag the FASM-specific array GC section** so the two backends' models aren't conflated.
- **Add a library ownership note:** a `Str`-returning library function must return a fresh heap block, since `jcc_gc_register` takes ownership and frees it.
- **Finalize GarbageCollection.md §Status** to the delivered state, naming the one deferred follow-up (COL string/closure enablement).

## Risks / follow-ups
- **Issue closure is a separate step:** #63 gets its Phase 8 tick and close after this merges to llvm-basic.

## Updated context
- Docs: docs/Arrays.md — corrected LLVM array-element GC note, tagged FASM section
- Docs: docs/system/standard-libraries.md — fresh-heap-block contract for Str-returning functions
- Docs: docs/GarbageCollection.md — §Status finalized to delivered state

## How to verify
- Read docs/Arrays.md against `AbstractLlvmCodeGenerator.java:230-233` (array element region → global root) and the `BasicLlvmGarbageCollectionHardeningIT` string-array scenario to confirm the corrected note is accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
