### PR TITLE
Document LLVM as a fully supported backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## What is this
 
-JCC (Johan Compiler Collection) is a multi-module compiler infrastructure for compiling four toy languages — BASIC, Tiny, Assembunny, and COL — to native executables. It supports two backends: FASM (Flat Assembler) for x86-64 assembly and an experimental LLVM IR backend. Built with ANTLR4 for parsing; implemented in Java 21 and Kotlin.
+JCC (Johan Compiler Collection) is a multi-module compiler infrastructure for compiling four toy languages — BASIC, Tiny, Assembunny, and COL — to native executables. It has two fully supported backends: FASM (Flat Assembler) for x86-64 assembly and an LLVM IR backend (via external Clang). Built with ANTLR4 for parsing; implemented in Java 21 and Kotlin.
 
 ## Stack
 
@@ -13,7 +13,7 @@ JCC (Johan Compiler Collection) is a multi-module compiler infrastructure for co
 | Parsing | ANTLR4 |
 | CLI parsing | JCommander |
 | Backends | FASM (x86-64 assembly, Windows-only); LLVM IR (via external Clang) |
-| Runtime libs | `msvcrt.dll`, `libjccbas.dll` (FASM backend); `libjccbas.a` (BASIC), `libjcccol.a` (COL) (LLVM backend) |
+| Runtime libs | `msvcrt.dll`, `libjccbas.dll` (FASM backend); `libjccbas.a` (BASIC), `libjcccol.a` (COL), plus `-lm` on Linux (LLVM backend) |
 | Testing | JUnit 5 |
 
 ## Directory index
@@ -66,5 +66,5 @@ For Java symbol navigation (go-to-definition, find-references, hover) and type/i
 
 - Only `fasm.exe` (assembling and running the output) is Windows-only; FASM *code generation* runs on any platform. Reproduce FASM codegen bugs off Windows with `java -jar jcc-compiler/target/jcc-compiler-*.jar -S program.bas`, which writes the `.asm` and stops before assembling. The FASM backend is slated for future deprecation in favor of the LLVM backend.
 - FASM compile-and-run ITs (`*CompileAndRunIT`) are annotated `@EnabledOnOs(OS.WINDOWS)` — they need `fasm.exe` to assemble and run, so they are silently skipped everywhere else. A change that breaks FASM compilation (e.g. a shared-semantics tightening) therefore passes a local `mvn verify` and the Linux/macOS CI legs; only the Windows CI leg catches it. The LLVM ITs (`*LlvmCompileAndRunIT`) are not OS-gated.
-- LLVM backend support is experimental; BASIC's LLVM support is still a work in progress.
+- The LLVM backend is fully supported across all four languages (BASIC, Tiny, Assembunny, COL). A few narrow BASIC gaps remain (e.g. `SLEEP` has no LLVM IT; `LINE INPUT;` `inhibitNewline` has no effect) — see `docs/system/standard-libraries.md`.
 - Integration tests in `jcc-compiler` compile via the test classpath, resolved from the local Maven repo — after changing another module, refresh the repo before running ITs or they exercise stale code. The only refresh observed to be reliable is `mvn clean install -DskipTests`: both `-pl jcc-compiler -am` and an incremental `mvn -pl <module> -am install` have produced jars missing changes that compiled minutes earlier. Manual `java -jar` runs additionally need the `dependency:copy-dependencies` refresh from Commands (and again after every `clean`). Stale jars show up as phantom failures: fixes that don't take effect, or ITs failing on features that exist in source.

--- a/README.md
+++ b/README.md
@@ -10,18 +10,30 @@
 ![Top Language](https://img.shields.io/github/languages/top/dykstrom/jcc)
 [![JDK compatibility: 21+](https://img.shields.io/badge/JDK_compatibility-21+-blue.svg)](https://adoptium.net)
 
-JCC, the Johan Compiler Collection, is a collection of toy compilers built using [ANTLR4](http://www.antlr.org) and [flat assembler](http://flatassembler.net). The current version of JCC compiles three programming languages: [Tiny](https://github.com/antlr/grammars-v4/tree/master/tiny), [Assembunny](http://adventofcode.com/2016/day/12), and a subset of [BASIC](https://en.wikipedia.org/wiki/BASIC).
+JCC, the Johan Compiler Collection, is a collection of toy compilers built using [ANTLR4](http://www.antlr.org). The current version of JCC compiles four programming languages: [Tiny](https://github.com/antlr/grammars-v4/tree/master/tiny), [Assembunny](http://adventofcode.com/2016/day/12), COL, and a subset of [BASIC](https://en.wikipedia.org/wiki/BASIC).
 
-JCC also has experimental support for [using LLVM as backend](docs/LLVM.md) instead of flat assembler.
+JCC has two fully supported backends: [flat assembler](http://flatassembler.net) (FASM), which emits x86-64 assembly, and [LLVM](docs/LLVM.md), which emits LLVM IR compiled by Clang. The FASM backend is the default; select the LLVM backend with `--backend LLVM`.
 
 ## System Requirements
+
+The requirements depend on which backend you use.
+
+### FASM backend (default)
 
 * Windows
 * Java 21+
 
-You can download the Java runtime from [Adoptium](https://adoptium.net).
+Executables created with the FASM backend depend on the library [msvcrt.dll](https://en.wikipedia.org/wiki/Microsoft_Windows_library_files), which is a part of Windows. BASIC executables also depend on the BASIC standard library, libjccbas.dll, that is distributed together with JCC.
 
-Executables created with JCC depend on the library [msvcrt.dll](https://en.wikipedia.org/wiki/Microsoft_Windows_library_files), which is a part of Windows. BASIC executables also depend on the BASIC standard library, libjccbas.dll, that is distributed together with JCC.
+### LLVM backend
+
+* Windows, Linux, or macOS
+* Java 21+
+* Clang 20+
+
+The LLVM backend works on Windows, Linux, and macOS, but it is not bundled with JCC: you need to install [Clang](https://clang.llvm.org) (version 20 or later) yourself. See [Using LLVM as Backend](docs/LLVM.md) for installation instructions. BASIC and COL executables depend on the static standard libraries libjccbas.a and libjcccol.a respectively, which are distributed together with JCC.
+
+You can download the Java runtime from [Adoptium](https://adoptium.net).
 
 ## Installation
 
@@ -52,12 +64,24 @@ This will print a message similar to this:
 ```
 Usage: jcc [options] <source file>
   Options:
+    --backend
+      Generate code for <backend>
+      Default: FASM
+      Possible Values: [FASM, LLVM]
     --help
       Show this help text
+    --library-path
+      Add <directory> to the linker's library search path
+    -v, --verbose
+      Verbose mode
+      Default: false
     --version
       Show compiler version
     -O, -O1
-      Optimize output
+      Optimization level 1
+      Default: false
+    -O2
+      Optimization level 2
       Default: false
     -S
       Compile only; do not assemble
@@ -65,12 +89,18 @@ Usage: jcc [options] <source file>
     -Wall
       Enable all warnings
       Default: false
+    -Wfloat-conversion
+      Warn about implicit float conversions
+      Default: false
     -Wundefined-variable
       Warn about undefined variables
       Default: false
+    -Wunused-variable
+      Warn about unused variables
+      Default: false
     -assembler
-      Use <assembler> as the backend assembler
-      Default: fasm
+      Use <assembler> as the backend assembler. Default: 'fasm' for the FASM
+      backend, and 'clang' for the LLVM backend
     -assembler-include
       Set the assembler's include directory to <directory>
     -initial-gc-threshold
@@ -84,10 +114,9 @@ Usage: jcc [options] <source file>
     -save-temps
       Save temporary intermediate files permanently
       Default: false
-    -v
-      Verbose mode
-      Default: false
 ```
+
+By default JCC uses the FASM backend. To compile with the LLVM backend instead, add `--backend LLVM`; see [Using LLVM as Backend](docs/LLVM.md) for details.
 
 ## Supported Languages
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![Top Language](https://img.shields.io/github/languages/top/dykstrom/jcc)
 [![JDK compatibility: 21+](https://img.shields.io/badge/JDK_compatibility-21+-blue.svg)](https://adoptium.net)
 
-JCC, the Johan Compiler Collection, is a collection of toy compilers built using [ANTLR4](http://www.antlr.org). The current version of JCC compiles four programming languages: [Tiny](https://github.com/antlr/grammars-v4/tree/master/tiny), [Assembunny](http://adventofcode.com/2016/day/12), COL, and a subset of [BASIC](https://en.wikipedia.org/wiki/BASIC).
+JCC, the Johan Compiler Collection, is a collection of toy compilers built using [ANTLR4](http://www.antlr.org). The current version of JCC compiles four programming languages: [Tiny](https://github.com/antlr/grammars-v4/tree/master/tiny), [Assembunny](http://adventofcode.com/2016/day/12), COL, and a subset of [QuickBASIC](https://en.wikipedia.org/wiki/QuickBASIC).
 
 JCC has two fully supported backends: [flat assembler](http://flatassembler.net) (FASM), which emits x86-64 assembly, and [LLVM](docs/LLVM.md), which emits LLVM IR compiled by Clang. The FASM backend is the default; select the LLVM backend with `--backend LLVM`.
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -156,7 +156,7 @@ The current version of JCC does not employ any intermediate representation durin
 The code generator converts the AST directly to assembly code. To enable advanced optimization and
 improve code quality, this will likely have to change in the future.
 
-However, JCC does have experimental support for [using LLVM as backend](LLVM.md) instead of flat assembler.
+However, JCC does have full support for [using LLVM as backend](LLVM.md) instead of flat assembler.
 Using LLVM requires using LLVM IR as intermediate representation.
 
 

--- a/docs/LLVM.md
+++ b/docs/LLVM.md
@@ -22,7 +22,7 @@ Please refer to the [LLVM documentation](https://llvm.org) or your package manag
 instructions on how to install LLVM. The list below is a very brief summary.
 
 * **Windows**: Download a prebuilt release from the [LLVM MinGW](https://github.com/mstorsjo/llvm-mingw)
-  project. JCC has been tested with release `llvm-mingw-20240619-ucrt-x86_64.zip`.
+  project. JCC has been tested with release `llvm-mingw-20251118-ucrt-aarch64`.
 * **macOS**: Install LLVM/Clang using [Homebrew](https://brew.sh): `brew install llvm`. Clang is
   also part of Xcode.
 * **Linux**: Install LLVM/Clang using your package manager. For example on Ubuntu:

--- a/docs/LLVM.md
+++ b/docs/LLVM.md
@@ -1,14 +1,14 @@
 # Using LLVM as Backend
 
-JCC has experimental support for using [LLVM](https://llvm.org) as backend. You enable LLVM support
-using the command line argument `--backend`:
+LLVM is one of JCC's two fully supported backends, alongside flat assembler (FASM). You select the
+LLVM backend using the command line argument `--backend`:
 
 ```bash
 $ jcc --backend LLVM ...
 ```
 
-Currently, LLVM support is limited to the languages Assembunny, COL, and Tiny. Furthermore, 
-LLVM is not included in the JCC package. You need to install LLVM, or to be more precise 
+The LLVM backend supports all four JCC languages: Assembunny, BASIC, COL, and Tiny. LLVM is not
+included in the JCC package, however. You need to install LLVM, or to be more precise
 [Clang](https://clang.llvm.org), yourself. JCC with LLVM as backend has been tested on Windows, Linux, and macOS.
 Thus, the system requirements for JCC with LLVM are:
 

--- a/docs/system/code-generation.md
+++ b/docs/system/code-generation.md
@@ -3,7 +3,7 @@
 JCC has two code-generation backends sharing a component-based design. Each AST node type maps to a code-generator component; the main generator dispatches by node class via a map lookup, and components recurse into child nodes and emit target instructions.
 
 - **FASM backend** (`jcc-base`, `AbstractCodeGenerator`): emits x86-64 Flat Assembler text. Output is a `.asm` file assembled by `FasmAssembler`. Windows-only.
-- **LLVM backend** (`jcc-llvm`, `AbstractLlvmCodeGenerator`): emits LLVM IR. Output is a `.ll` file compiled by `LlvmAssembler` (clang). Experimental.
+- **LLVM backend** (`jcc-llvm`, `AbstractLlvmCodeGenerator`): emits LLVM IR. Output is a `.ll` file compiled by `LlvmAssembler` (clang). Cross-platform; requires a user-installed Clang 20+.
 
 Both produce a `TargetProgram` whose `toText()` is written to the intermediate file. The backend is selected by `CompilerFactory` from the `--backend` flag (default FASM).
 
@@ -103,7 +103,7 @@ COL `val` declarations span semantics and codegen:
 
 ## BASIC LLVM coverage
 
-The BASIC LLVM backend is a work in progress. Coverage is exactly the set of components registered in `BasicLlvmCodeGenerator` merged with the base LLVM dictionaries. Statement/expression registrations are at parity with the FASM `BasicCodeGenerator`, including the nodes the shared `DefaultAstOptimizer` emits at `-O1` (Inc/Dec, Add/Sub/Mul/IDivAssign, `ShiftLeftExpression`) — the optimizer runs for both backends, so a node it emits must be registered in both. The LLVM op-assign generators take a `Scope` like `AssignCodeGenerator`: the base dictionary registers them with `NONE` (declared-variable languages), `BasicLlvmCodeGenerator` re-registers them with `GLOBAL`, because at `-O1` an optimized assignment can be a variable's first use.
+The BASIC LLVM backend is fully supported. Coverage is exactly the set of components registered in `BasicLlvmCodeGenerator` merged with the base LLVM dictionaries. Statement/expression registrations are at parity with the FASM `BasicCodeGenerator`, including the nodes the shared `DefaultAstOptimizer` emits at `-O1` (Inc/Dec, Add/Sub/Mul/IDivAssign, `ShiftLeftExpression`) — the optimizer runs for both backends, so a node it emits must be registered in both. The LLVM op-assign generators take a `Scope` like `AssignCodeGenerator`: the base dictionary registers them with `NONE` (declared-variable languages), `BasicLlvmCodeGenerator` re-registers them with `GLOBAL`, because at `-O1` an optimized assignment can be a variable's first use.
 
 Known divergences from FASM: `RETURN` without `GOSUB` prints `Error: GOSUB stack underflow (RETURN without GOSUB)` to stderr and exits 1, where FASM prints `Error: RETURN without GOSUB` to stdout and exits 0 (pinned by `BasicLlvmCompileAndRunControlStructuresIT`). `LBOUND`/`UBOUND` with an out-of-range dimension is an unchecked read of the dims global on LLVM, where FASM raises `Error: Illegal function call` at runtime — deliberately untested because the output is not stable.
 


### PR DESCRIPTION
## What is this

The LLVM IR backend is no longer experimental — it now covers all four languages (BASIC, Tiny, Assembunny, COL) and is exercised by non-OS-gated compile-and-run tests. The documentation still described it as experimental and BASIC-LLVM as a work in progress, and the README documented only one backend's requirements. This updates the docs to match reality.

## Approach

- **Two supported backends:** reframe README, `AGENTS.md`, `docs/LLVM.md`, and `docs/Architecture.md` to present FASM and LLVM as equals.
- **Per-backend requirements in README:** split System Requirements into FASM (Windows) and LLVM (Win/Linux/macOS, user-installed Clang 20+).
- **Regenerated `--help` block:** captured live `jcc --help` output rather than hand-editing, so it matches `Jcc.java` (adds `--backend`, `--library-path`, `-O2`, and more).
- **COL, brief only:** fixed the language count and added a COL mention; no full COL section.

## Updated context

- Docs: `README.md` — two-backend framing, per-backend requirements, corrected `--help` and language count.
- Docs: `docs/LLVM.md` — LLVM no longer experimental; now all four languages.
- Docs: `AGENTS.md` — backend status, runtime-libs row (`-lm` on Linux), and the experimental/WIP gotcha corrected.
- Docs: `docs/Architecture.md`, `docs/system/code-generation.md` — LLVM/BASIC-LLVM status wording updated.

## How to verify

- Confirm the README `--help` block matches the tool: `java -jar jcc-compiler/target/jcc-compiler-*.jar --help` (needs the `dependency:copy-dependencies` refresh from AGENTS.md first).
