### PR TITLE
Add release workflow triggered by version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  verify-branch:
+    name: Verify tag is on master
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check tag is on master
+        run: |
+          TAG_COMMIT=$(git rev-list -n 1 "$GITHUB_REF")
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/master; then
+            echo "Tag is NOT on master branch"
+            exit 1
+          fi
+          echo "Tag is on master branch"
+
+  build:
+    name: Build on ${{ matrix.os-name }} (${{ matrix.arch }})
+    needs: verify-branch
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            os-name: linux
+            arch: x86_64
+            artifact-name: Linux-x86_64-artifacts
+            ext: tar.gz
+          - os: ubuntu-24.04-arm
+            os-name: linux
+            arch: arm64
+            artifact-name: Linux-arm64-artifacts
+            ext: tar.gz
+          - os: macos-latest
+            os-name: macos
+            arch: arm64
+            artifact-name: macOS-arm64-artifacts
+            ext: tar.gz
+          - os: macos-15-intel
+            os-name: macos
+            arch: x86_64
+            artifact-name: macOS-x86_64-artifacts
+            ext: tar.gz
+          - os: windows-latest
+            os-name: windows
+            arch: x86_64
+            artifact-name: Windows-x86_64-artifacts
+            ext: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+      - name: Rename artifact to include OS and architecture
+        shell: bash
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          src=$(ls jcc-compiler/target/jcc-*-bin.${{ matrix.ext }})
+          mv "$src" "jcc-compiler/target/jcc-${VERSION}-${{ matrix.os-name }}-${{ matrix.arch }}.${{ matrix.ext }}"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: jcc-compiler/target/jcc-*-${{ matrix.os-name }}-${{ matrix.arch }}.${{ matrix.ext }}
+
+  release:
+    name: Create release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: artifacts/
+          merge-multiple: true
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+          files: artifacts/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/system/build.md
+++ b/docs/system/build.md
@@ -78,6 +78,25 @@ the bug is fixed or the pattern is deliberately added to the filter. Current exc
 These exclusions took the analysis from a ~155-finding baseline to zero, after which the
 build was switched from report-only to blocking.
 
+## Releases
+
+Releases are cut by pushing a `v<version>` tag (e.g. `v0.11.0`) on `master`.
+`.github/workflows/release.yml` then runs a `verify-branch` guard (the tag must be
+an ancestor of `origin/master`), builds the distribution on all five platforms with
+`mvn -B package`, and publishes a GitHub Release named with the version only
+(leading `v` stripped), attaching one archive per platform (`.zip` for Windows,
+`.tar.gz` for Linux/macOS).
+
+The release build uses `mvn package`, not `verify` — it skips the LLVM integration
+tests, so no Clang setup is needed on the release runners.
+
+Two couplings fail silently if broken:
+- The maven-release-plugin `<tagNameFormat>v@{project.version}</tagNameFormat>` in
+  the parent POM must match the workflow's `v*` trigger. Change one without the
+  other and `release:perform` produces a tag that never triggers a release.
+- Tag-triggered workflows run the workflow file as it exists at the tagged commit.
+  `release.yml` must be present on `master` for a release to fire.
+
 ## Kotlin incremental compilation is disabled
 
 The parent POM pins `kotlin.compiler.incremental` to `false`. When it was enabled,

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.0.0</version>
+                <configuration>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What is this

JCC had CI build workflows but no automated release — cutting one meant building each platform's distribution archive by hand and uploading it to a GitHub Release. This adds a tag-triggered release workflow: pushing a `v<version>` tag on `master` builds the distribution on all five supported platforms and publishes a GitHub Release named with the version, one archive per platform.

## Approach

- **Tag trigger + master guard:** fires on `v*` tags; a `verify-branch` job fails the run unless the tagged commit is an ancestor of `origin/master`.
- **Matrix over the same 5 platforms** as the existing build workflows (Linux x86_64/arm64, macOS arm64/x86_64, Windows x86_64).
- **`mvn -B package`, no Clang:** the release build skips the LLVM integration tests, so release runners need no Clang setup.
- **One archive per platform:** Windows `.zip`, others `.tar.gz`, renamed to embed OS and arch (e.g. `jcc-0.11.0-linux-x86_64.tar.gz`).
- **Release named with version only** (leading `v` stripped), notes auto-generated by `action-gh-release`.
- **`tagNameFormat` set to `v@{project.version}`** so `release:prepare` produces the `v<version>` tags the workflow triggers on — replacing the previous default `jcc-parent-<version>` tags.

## Risks / follow-ups

- **Takes effect only on master:** tag-triggered workflows run the workflow file as it exists at the tagged commit, so this can't fire until it lands on `master`.
- **Coupled trigger/tag format:** the `v*` trigger and the pom `tagNameFormat` must stay in sync; changing one without the other silently stops releases. Documented in `docs/system/build.md`.
- **`action-gh-release` pinned to `@v2`** — bump if you prefer a newer major.

## Updated context

- Docs: `docs/system/build.md` — new "Releases" section describing the tag-triggered release process and the two silent-failure couplings.

## How to verify

- After this reaches `master`, push a `v<version>` tag on `master` and confirm the workflow builds all five platforms and creates a Release named e.g. `0.11.0` with one archive per platform attached. A tag on a non-master commit should fail at the `verify-branch` job.
