### PR TITLE
Fix pipe-buffer deadlock reading child process output

### DIFF
--- a/docs/system/build.md
+++ b/docs/system/build.md
@@ -97,6 +97,19 @@ Two couplings fail silently if broken:
 - Tag-triggered workflows run the workflow file as it exists at the tagged commit.
   `release.yml` must be present on `master` for a release to fire.
 
+## Integration-test process harness
+
+`ProcessUtils.setUpProcess` (in `jcc-base`) starts each compiled test program,
+then drains its combined stdout/stderr on a background daemon thread while
+`waitFor` blocks; `readOutput` returns the captured buffer afterward. The
+draining must stay concurrent. If a change reads output only after `waitFor`
+returns, a program that writes more than the OS pipe buffer (~4 KB on Windows
+anonymous pipes) blocks on `write` and never exits, so `waitFor` times out and
+the test fails with "Process is still alive". This surfaces only on the
+Windows-only FASM run and the LLVM IT paths, neither on CI, and depends on
+output volume — e.g. a `-print-gc` GC log crossing 4 KB. The same harness backs
+`LlvmAssembler` and `FasmAssembler`.
+
 ## Kotlin incremental compilation is disabled
 
 The parent POM pins `kotlin.compiler.incremental` to `false`. When it was enabled,

--- a/jcc-base/src/main/java/se/dykstrom/jcc/common/utils/ProcessUtils.java
+++ b/jcc-base/src/main/java/se/dykstrom/jcc/common/utils/ProcessUtils.java
@@ -36,6 +36,9 @@ public final class ProcessUtils {
 
     private ProcessUtils() { }
 
+    /** Timeout for waiting on a process to exit, and for its output-draining thread to finish. */
+    private static final long TIMEOUT_SECONDS = 10;
+
     /** Holds the output captured for each running process, keyed by the process itself. */
     private static final Map<Process, OutputCapture> CAPTURES = new ConcurrentHashMap<>();
 
@@ -80,7 +83,7 @@ public final class ProcessUtils {
         capture.start();
 
         // Wait for the process to start and then end
-        process.waitFor(10, TimeUnit.SECONDS);
+        process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // Return the already ended process
         return process;
@@ -142,7 +145,7 @@ public final class ProcessUtils {
 
         String getOutput() {
             try {
-                thread.join(TimeUnit.SECONDS.toMillis(10));
+                thread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/jcc-base/src/main/java/se/dykstrom/jcc/common/utils/ProcessUtils.java
+++ b/jcc-base/src/main/java/se/dykstrom/jcc/common/utils/ProcessUtils.java
@@ -37,7 +37,7 @@ public final class ProcessUtils {
     private ProcessUtils() { }
 
     /** Timeout for waiting on a process to exit, and for its output-draining thread to finish. */
-    private static final long TIMEOUT_SECONDS = 10;
+    private static final long TIMEOUT_MILLIS = 10_000;
 
     /** Holds the output captured for each running process, keyed by the process itself. */
     private static final Map<Process, OutputCapture> CAPTURES = new ConcurrentHashMap<>();
@@ -83,7 +83,7 @@ public final class ProcessUtils {
         capture.start();
 
         // Wait for the process to start and then end
-        process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        process.waitFor(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
         // Return the already ended process
         return process;
@@ -145,7 +145,7 @@ public final class ProcessUtils {
 
         String getOutput() {
             try {
-                thread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+                thread.join(TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/jcc-base/src/main/java/se/dykstrom/jcc/common/utils/ProcessUtils.java
+++ b/jcc-base/src/main/java/se/dykstrom/jcc/common/utils/ProcessUtils.java
@@ -24,6 +24,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -34,6 +35,9 @@ import java.util.concurrent.TimeUnit;
 public final class ProcessUtils {
 
     private ProcessUtils() { }
+
+    /** Holds the output captured for each running process, keyed by the process itself. */
+    private static final Map<Process, OutputCapture> CAPTURES = new ConcurrentHashMap<>();
 
     /**
      * Sets up and returns a new process that executes the given {@code command}.
@@ -46,13 +50,7 @@ public final class ProcessUtils {
     public static Process setUpProcess(List<String> command, Map<String, String> addEnv) throws IOException, InterruptedException {
         ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true);
         builder.environment().putAll(addEnv);
-        Process process = builder.start();
-
-        // Wait for the process to start and then end
-        process.waitFor(10, TimeUnit.SECONDS);
-
-        // Return the already ended process
-        return process;
+        return startAndWait(builder);
     }
 
     /**
@@ -68,7 +66,18 @@ public final class ProcessUtils {
     public static Process setUpProcess(List<String> command, File inputFile, Map<String, String> addEnv) throws IOException, InterruptedException {
         ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true).redirectInput(inputFile);
         builder.environment().putAll(addEnv);
+        return startAndWait(builder);
+    }
+
+    private static Process startAndWait(ProcessBuilder builder) throws IOException, InterruptedException {
         Process process = builder.start();
+
+        // Drain the process output on a background thread. Otherwise a process that writes more
+        // than the OS pipe buffer (~4 KB on Windows) blocks on write and never exits, because
+        // nothing reads the pipe until after waitFor returns.
+        OutputCapture capture = new OutputCapture(process);
+        CAPTURES.put(process, capture);
+        capture.start();
 
         // Wait for the process to start and then end
         process.waitFor(10, TimeUnit.SECONDS);
@@ -82,6 +91,7 @@ public final class ProcessUtils {
      */
     public static void tearDownProcess(Process process) {
         process.destroy();
+        CAPTURES.remove(process);
     }
 
     /**
@@ -91,17 +101,54 @@ public final class ProcessUtils {
      * @return The process output.
      */
     public static String readOutput(Process process) {
-        StringBuilder builder = new StringBuilder();
+        OutputCapture capture = CAPTURES.get(process);
+        return (capture != null) ? capture.getOutput() : "";
+    }
 
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), Charset.defaultCharset()))) {
-            while (reader.ready()) {
-                String str = reader.readLine();
-                builder.append(str).append("\n");
-            }
-        } catch (IOException e) {
-            builder.append(e.getMessage()).append("\n");
+    /**
+     * Reads a process's combined stdout/stderr to EOF on a daemon thread, so the process is never
+     * blocked by a full pipe buffer.
+     */
+    private static final class OutputCapture {
+
+        private final Process process;
+        private final StringBuilder builder = new StringBuilder();
+        private final Thread thread;
+
+        OutputCapture(Process process) {
+            this.process = process;
+            this.thread = new Thread(this::drain, "process-output-capture");
+            this.thread.setDaemon(true);
         }
 
-        return builder.toString();
+        void start() {
+            thread.start();
+        }
+
+        private void drain() {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), Charset.defaultCharset()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    synchronized (builder) {
+                        builder.append(line).append("\n");
+                    }
+                }
+            } catch (IOException e) {
+                synchronized (builder) {
+                    builder.append(e.getMessage()).append("\n");
+                }
+            }
+        }
+
+        String getOutput() {
+            try {
+                thread.join(TimeUnit.SECONDS.toMillis(10));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            synchronized (builder) {
+                return builder.toString();
+            }
+        }
     }
 }

--- a/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/AbstractIntegrationTests.kt
+++ b/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/AbstractIntegrationTests.kt
@@ -23,6 +23,7 @@ import se.dykstrom.jcc.common.utils.ProcessUtils
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 
 /**
  * Abstract base class for integration tests.
@@ -276,8 +277,10 @@ abstract class AbstractIntegrationTests {
 
             var process: Process? = null
             try {
+                val start = System.nanoTime()
                 process = ProcessUtils.setUpProcess(listOf(outputPath.toString()), inputFile, emptyMap())
-                assertFalse(process.isAlive, "Process is still alive")
+                val end = System.nanoTime()
+                assertFalse(process.isAlive, "Process is still alive after " + TimeUnit.NANOSECONDS.toSeconds(end - start) + " seconds")
                 assertEquals(0, process.exitValue(), "Exit value differs:")
                 return ProcessUtils.readOutput(process)
             } finally {


### PR DESCRIPTION
## What

`ProcessUtils.setUpProcess` waited for the child process to exit *before* anything read its stdout. A child that writes more than the OS pipe buffer (~4 KB on Windows anonymous pipes) blocks on `write()` and never exits, so `waitFor` times out and the test sees the process as still alive.

Surfaced by `BasicLlvmGarbageCollectionHardeningIT.shouldKeepFramesBalancedAcrossManyNestedCalls` on Windows/arm64: it emits the most `-print-gc` log of the class (threshold never grows → ~240 collections), pushing program output to 4439 bytes — just over the 4096-byte pipe limit. Running the binary standalone (stdout to a drained console) finished in <1s; only the undrained-pipe test path hung.

## Approach

- `setUpProcess` now spawns a background **daemon thread** that drains the child's combined stdout/stderr to EOF into a buffer (keyed by `Process`) *while* `waitFor` runs, so the child can never fill the pipe.
- `readOutput` returns that captured buffer; `tearDownProcess` clears the entry. This also removes the old `reader.ready()` read, which could truncate output at a momentary gap.
- Same latent hang is fixed for the production callers `LlvmAssembler` (clang) and `FasmAssembler`.
- `AbstractIntegrationTests.compileAndRunLlvmReturningOutput` gains a timing-aware assertion message ("still alive after N seconds") for better future diagnosis.

## Updated context

Verified on macOS (Clang 22): `mvn clean install` green; full `mvn -P llvm-tests verify` = **145 LLVM ITs, 0 failures, 0 skipped**, including all 9 in `BasicLlvmGarbageCollectionHardeningIT`. Confirmed fixed on Windows/arm64 by the reporter. macOS could not reproduce the original hang (larger ~64 KB pipe buffer), so it serves as the regression check; Windows is the fix confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)