### PR TITLE
Slim down README; add contributor and language docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ docs/
 └── working-notes/  ← research; NOT authoritative — rules live in architecture/ + adr/
 ```
 
-`docs/` also holds existing hand-written docs (`Architecture.md`, `Arrays.md`, `GarbageCollector.md`, `LLVM.md`, `diagrams/`).
+`docs/` also holds existing hand-written docs (`Architecture.md`, `Arrays.md`, `GarbageCollector.md`, `LLVM.md`, `diagrams/`) and `docs/languages/` — user-facing language guides linked from the README. Note the two parallel language-doc sets: `docs/languages/<lang>.md` is the user-facing guide; `docs/system/<lang>-language.md` records agent-facing gotchas. Keep them distinct.
 
 ## Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to JCC
+
+Thanks for your interest in JCC. This document describes how the repository is
+organized into branches and how changes make their way into a release.
+
+For build and test commands, see [AGENTS.md](AGENTS.md).
+
+## Branch model
+
+JCC uses two long-lived branches:
+
+- **`master`** — the stable release branch, and the default branch on GitHub.
+  Every tagged release is cut from here. It should always build.
+- **`dev`** — the active integration branch. All day-to-day work lands here
+  first and is stabilized before the next release.
+
+## Feature branches
+
+Create a branch off `dev` for each change. Name it `type/short-description`,
+where `type` is one of:
+
+| Prefix | Used for |
+|--------|----------|
+| `feature/` | New functionality |
+| `fix/` | Bug fixes |
+| `docs/` | Documentation only |
+| `ci/` | Build and CI changes |
+
+For example: `fix/process-output-pipe-deadlock`.
+
+## Landing a change
+
+1. Open a pull request from your feature branch into `dev`.
+2. Merge it as a **squash merge**, so `dev` keeps a single, clean commit per
+   change.
+3. Delete the feature branch after it is merged.
+
+## Releases
+
+At release time, `dev` is merged into `master`. The release itself is driven by
+the Maven release plugin, which tags the release version and then bumps the
+project to the next development iteration — the
+`[maven-release-plugin] prepare release` and
+`[maven-release-plugin] prepare for next development iteration` commits.
+
+## Hotfixes
+
+An urgent bug fix may be committed directly on `master` and then merged back into
+`dev` to keep the two branches in sync. In practice this is rare — JCC is a
+single-maintainer project, so almost everything flows through `dev`.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,16 @@
 ![Top Language](https://img.shields.io/github/languages/top/dykstrom/jcc)
 [![JDK compatibility: 21+](https://img.shields.io/badge/JDK_compatibility-21+-blue.svg)](https://adoptium.net)
 
-JCC, the Johan Compiler Collection, is a collection of toy compilers built using [ANTLR4](http://www.antlr.org). The current version of JCC compiles four programming languages: [Tiny](https://github.com/antlr/grammars-v4/tree/master/tiny), [Assembunny](http://adventofcode.com/2016/day/12), COL, and a subset of [QuickBASIC](https://en.wikipedia.org/wiki/QuickBASIC).
+JCC, the Johan Compiler Collection, is a collection of toy compilers built with
+[ANTLR4](http://www.antlr.org). It compiles four small programming languages —
+[BASIC](docs/languages/basic.md), [COL](docs/languages/col.md),
+[Tiny](docs/languages/tiny.md), and [Assembunny](docs/languages/assembunny.md) —
+to native executables.
 
-JCC has two fully supported backends: [flat assembler](http://flatassembler.net) (FASM), which emits x86-64 assembly, and [LLVM](docs/LLVM.md), which emits LLVM IR compiled by Clang. The FASM backend is the default; select the LLVM backend with `--backend LLVM`.
+JCC has two fully supported backends: [flat assembler](http://flatassembler.net)
+(FASM), which emits x86-64 assembly, and [LLVM](docs/LLVM.md), which emits LLVM IR
+compiled by Clang. The FASM backend is the default; select the LLVM backend with
+`--backend LLVM`.
 
 ## System Requirements
 
@@ -118,151 +125,18 @@ Usage: jcc [options] <source file>
 
 By default JCC uses the FASM backend. To compile with the LLVM backend instead, add `--backend LLVM`; see [Using LLVM as Backend](docs/LLVM.md) for details.
 
-## Supported Languages
+## Languages
 
-### Assembunny
+JCC compiles four small languages. Each has its own guide:
 
-[Assembunny](http://adventofcode.com/2016/day/12) is a made up programming language from the programming challenge [Advent of Code 2016](http://adventofcode.com/2016). It is a small assembly language with only four instructions: _inc_, _dec_, _cpy_, and _jnz_. To make the language more interesting I have also added support for the _outn_ instruction from the Assembunny extension [Assembunny-Plus](https://github.com/broad-well/assembunny-plus/blob/master/doc/spec.md).
+| Language | Description | Extension |
+|----------|-------------|-----------|
+| [BASIC](docs/languages/basic.md) | A subset of Microsoft QuickBASIC 4.5, with a garbage collector for dynamic strings. | `.bas` |
+| [COL](docs/languages/col.md) | A statically typed language with functional elements, inspired by BASIC, C, Go, and Rust. | `.col` |
+| [Tiny](docs/languages/tiny.md) | A minimal educational language for reading input, computing, and writing output. | `.tiny` |
+| [Assembunny](docs/languages/assembunny.md) | A tiny assembly language from Advent of Code 2016. | `.asmb` |
 
-This is an example of Assembunny code:
+## Contributing
 
-```
-cpy 3 a
-inc a
-outn a
-```
-
-Assembunny files end with the file extension ".asmb".
-
-### BASIC
-
-[BASIC](https://en.wikipedia.org/wiki/BASIC) was invented in the sixties, and became very popular on home computers in the eighties. JCC BASIC is inspired by
-[Microsoft QuickBASIC](https://en.wikipedia.org/wiki/QuickBASIC) 4.5 from 1988. The current version of JCC implements a subset of BASIC. It does, however, come with a mark-and-sweep garbage collector to keep track of dynamic strings.
-
-The example below is a short program to compute prime numbers:
-
-```BASIC
-' Calculate all primes less than a number N
-
-CONST N = 100
-
-DIM index AS INTEGER
-DIM isPrime AS INTEGER
-DIM maxIndex as INTEGER
-DIM number AS INTEGER
-DIM primes(N) AS INTEGER
-
-number = 2
-WHILE number < N
-
-    ' Check if number is prime
-    isPrime = 1
-    index = 0
-    WHILE isPrime AND index < maxIndex
-        ' If number is dividable by any prime found so far, it is not prime
-        isPrime = number MOD primes(index)
-        index = index + 1
-    WEND
-
-    ' Print number if prime
-    IF isPrime THEN
-        PRINT number
-        primes(maxIndex) = number
-        maxIndex = maxIndex + 1
-    END IF
-
-    number = number + 1
-WEND
-```
-
-This table specifies the BASIC constructs that have been implemented so far:
-
-<table>
-  <tr>
-    <td>Data Types</td>
-    <td>
-        DOUBLE (64-bit)<br/>
-        INTEGER (64-bit)<br/>
-        STRING<br/>
-        Static arrays of the types above. Dynamic arrays are not supported.
-    </td>
-  </tr>
-  <tr>
-    <td>Arithmetic Operators</td>
-    <td>^ + - * / \ MOD</td>
-  </tr>
-  <tr>
-    <td>Relational Operators</td>
-    <td>= <> > >= < <=</td>
-  </tr>
-  <tr>
-    <td>Bitwise Operators</td>
-    <td>AND, EQV, IMP, NOT, OR, XOR</td>
-  </tr>
-  <tr>
-    <td>Control Structures</td>
-    <td>
-        GOSUB-RETURN<br>
-        GOTO<br>
-        IF-GOTO<br>
-        IF-THEN-ELSE (including ELSEIF)<br>
-        ON-GOSUB-RETURN<br>
-        ON-GOTO<br>
-        WHILE-WEND
-    </td>
-  </tr>
-  <tr>
-    <td>Statements</td>
-    <td>
-        CLS<br>
-        CONST<br>
-        DEFDBL<br>
-        DEFINT<br>
-        DEFSTR<br>
-        DIM<br>
-        END<br>
-        LET<br>
-        LINE INPUT<br>
-        OPTION BASE<br>
-        PRINT<br>
-        RANDOMIZE<br>
-        REM<br>
-        SLEEP<br>
-        SWAP<br>
-        SYSTEM
-    </td>
-  </tr>
-  <tr>
-    <td>Functions</td>
-    <td>
-        abs, asc, atn, cdbl, chr$, cint, command$, cos, csrlin, cvd, cvi, date$, exp, fix, hex$, inkey$, 
-        instr, int, lbound, lcase$, left$, len, log, ltrim$, mid$, mkd$, mki$, oct$, pos, right$, 
-        rnd, rtrim$, sgn, sin, space$, sqr, str$, string$, tan, time$, timer, ubound, 
-        ucase$, val
-    </td>
-  </tr>
-  <tr>
-    <td>User-defined Functions</td>
-    <td>
-        DEF FN expression functions
-    </td>
-  </tr>
-</table>
-
-BASIC files end with the file extension ".bas". BASIC executables require the BASIC standard library to run. This library is distributed together with JCC in the form of a DLL file: libjccbas.dll.
-
-### Tiny
-
-[Tiny](https://github.com/antlr/grammars-v4/tree/master/tiny) is a small programming language, designed for educational purposes.
-
-A typical Tiny program looks like this:
-
-```
-BEGIN
-    READ a, b
-    c := a + b
-    WRITE c
-END
-```
-
-Tiny files end with the file extension ".tiny".
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the branch workflow, and
+[AGENTS.md](AGENTS.md) for build and test commands.

--- a/docs/languages/assembunny.md
+++ b/docs/languages/assembunny.md
@@ -1,0 +1,31 @@
+# Assembunny
+
+[Assembunny](http://adventofcode.com/2016/day/12) is a made-up assembly language
+from the programming challenge [Advent of Code 2016](http://adventofcode.com/2016).
+It has four core instructions — `inc`, `dec`, `cpy`, and `jnz`. JCC also supports
+the `outn` instruction from the
+[Assembunny-Plus](https://github.com/broad-well/assembunny-plus/blob/master/doc/spec.md)
+extension, which makes the language interesting enough to produce output.
+
+## Example
+
+```
+cpy 3 a
+inc a
+outn a
+```
+
+## Language summary
+
+| Instruction | Meaning |
+|-------------|---------|
+| `inc x` | Increment register `x` |
+| `dec x` | Decrement register `x` |
+| `cpy x y` | Copy value `x` into register `y` |
+| `jnz x y` | Jump `y` instructions if `x` is non-zero |
+| `outn x` | Print the value of `x` as a number (Assembunny-Plus) |
+
+## File extension and runtime
+
+Assembunny source files use the `.asmb` extension. Assembunny programs have no
+runtime library dependency beyond the C runtime.

--- a/docs/languages/basic.md
+++ b/docs/languages/basic.md
@@ -1,0 +1,130 @@
+# BASIC
+
+[BASIC](https://en.wikipedia.org/wiki/BASIC) was invented in the 1960s and became
+hugely popular on home computers in the 1980s. JCC's dialect is inspired by
+[Microsoft QuickBASIC](https://en.wikipedia.org/wiki/QuickBASIC) 4.5 from 1988.
+JCC implements a subset of QuickBASIC, and adds a mark-and-sweep garbage collector
+to manage dynamic strings.
+
+## Example
+
+The program below computes all prime numbers less than a given number `N`:
+
+```BASIC
+' Calculate all primes less than a number N
+
+CONST N = 100
+
+DIM index AS INTEGER
+DIM isPrime AS INTEGER
+DIM maxIndex as INTEGER
+DIM number AS INTEGER
+DIM primes(N) AS INTEGER
+
+number = 2
+WHILE number < N
+
+    ' Check if number is prime
+    isPrime = 1
+    index = 0
+    WHILE isPrime AND index < maxIndex
+        ' If number is dividable by any prime found so far, it is not prime
+        isPrime = number MOD primes(index)
+        index = index + 1
+    WEND
+
+    ' Print number if prime
+    IF isPrime THEN
+        PRINT number
+        primes(maxIndex) = number
+        maxIndex = maxIndex + 1
+    END IF
+
+    number = number + 1
+WEND
+```
+
+## Language summary
+
+The table below lists the BASIC constructs implemented so far.
+
+<table>
+  <tr>
+    <td>Data Types</td>
+    <td>
+        DOUBLE (64-bit)<br/>
+        INTEGER (64-bit)<br/>
+        STRING<br/>
+        Static arrays of the types above. Dynamic arrays are not supported.
+    </td>
+  </tr>
+  <tr>
+    <td>Arithmetic Operators</td>
+    <td>^ + - * / \ MOD</td>
+  </tr>
+  <tr>
+    <td>Relational Operators</td>
+    <td>= &lt;&gt; &gt; &gt;= &lt; &lt;=</td>
+  </tr>
+  <tr>
+    <td>Bitwise Operators</td>
+    <td>AND, EQV, IMP, NOT, OR, XOR</td>
+  </tr>
+  <tr>
+    <td>Control Structures</td>
+    <td>
+        GOSUB-RETURN<br>
+        GOTO<br>
+        IF-GOTO<br>
+        IF-THEN-ELSE (including ELSEIF)<br>
+        ON-GOSUB-RETURN<br>
+        ON-GOTO<br>
+        WHILE-WEND
+    </td>
+  </tr>
+  <tr>
+    <td>Statements</td>
+    <td>
+        CLS<br>
+        CONST<br>
+        DEFDBL<br>
+        DEFINT<br>
+        DEFSTR<br>
+        DIM<br>
+        END<br>
+        LET<br>
+        LINE INPUT<br>
+        OPTION BASE<br>
+        PRINT<br>
+        RANDOMIZE<br>
+        REM<br>
+        SLEEP<br>
+        SWAP<br>
+        SYSTEM
+    </td>
+  </tr>
+  <tr>
+    <td>Functions</td>
+    <td>
+        abs, asc, atn, cdbl, chr$, cint, command$, cos, csrlin, cvd, cvi, date$, exp, fix, hex$, inkey$,
+        instr, int, lbound, lcase$, left$, len, log, ltrim$, mid$, mkd$, mki$, oct$, pos, right$,
+        rnd, rtrim$, sgn, sin, space$, sqr, str$, string$, tan, time$, timer, ubound,
+        ucase$, val
+    </td>
+  </tr>
+  <tr>
+    <td>User-defined Functions</td>
+    <td>
+        DEF FN expression functions
+    </td>
+  </tr>
+</table>
+
+Note that BASIC keywords are case-insensitive, but built-in function names must be
+written in lowercase.
+
+## File extension and runtime
+
+BASIC source files use the `.bas` extension. BASIC executables require the BASIC
+standard library to run. This library is distributed together with JCC as
+`libjccbas.dll` for the FASM backend and `libjccbas.a` for the LLVM backend.

--- a/docs/languages/col.md
+++ b/docs/languages/col.md
@@ -1,0 +1,57 @@
+# COL
+
+COL is a small language that exists only in this project — a playground for
+experimenting with language and compiler ideas. It is an imperative, statically
+typed language with functional elements, inspired by BASIC, C, Go, and Rust.
+
+Its guiding style is *words over symbols*: `and` instead of `&&`, `div` and `mod`
+for integer division, and `if c then a else b` instead of `c ? a : b`. The
+familiar arithmetic, relational, and bitwise operators stay symbolic. The LLVM
+backend is the primary target for COL.
+
+## Example
+
+Recursion is one of COL's two loop mechanisms (the other is the `while` loop).
+Because deep recursion must not grow the stack, COL provides `become`, which turns
+a tail call into a guaranteed constant-stack call at every optimization level. The
+program below computes factorials with both plain and tail recursion:
+
+```
+// Plain recursion
+fun fac(n as i64) -> i64 :=
+    if n <= 1 then 1 else n * fac(n - 1)
+
+// Tail-recursion, made a language guarantee with become
+fun fac_iter(n as i64) -> i64 :=
+    become fac_iter(n, 1)
+
+fun fac_iter(n as i64, result as i64) -> i64 :=
+    if n <= 1 then result else become fac_iter(n - 1, n * result)
+
+// Main
+call println(fac(5))
+call println(fac_iter(5))
+```
+
+## Language summary
+
+- **Types** — `i32`, `i64`, `f32`, `f64`, `bool`, and function types written
+  `(i64, i64) -> i64`. Conversions are explicit except for lossless widening.
+- **Functions** — `fun name(p as type, ...) -> rettype := expr` defines an
+  expression function (the body is a single expression). Functions are
+  first-class and may be overloaded by arity and parameter types.
+- **Values** — `val name [as type] := expr` declares an immutable value. COL has
+  no mutable variables.
+- **Control flow** — `while cond do ... end` loops, and `if cond then a else b`
+  as an expression.
+- **Tail calls** — prefix a tail call with `become` to guarantee constant-stack
+  recursion.
+- **Built-ins** — casts (`i32`, `i64`, `f32`, `f64`), math (`abs`, `sqrt`, `pow`,
+  `sin`, `log`, ...), `millis()`, and `println(x)`.
+
+## File extension and runtime
+
+COL source files use the `.col` extension. COL executables require the COL
+standard library, `libjcccol.a`, which is distributed together with JCC. COL is
+best used with the LLVM backend; the FASM backend still compiles COL but is being
+phased out.

--- a/docs/languages/tiny.md
+++ b/docs/languages/tiny.md
@@ -1,0 +1,28 @@
+# Tiny
+
+[Tiny](https://github.com/antlr/grammars-v4/tree/master/tiny) is a small
+programming language designed for educational purposes. It is the simplest of the
+languages JCC compiles — just enough to read input, do arithmetic, and write
+output.
+
+## Example
+
+```
+BEGIN
+    READ a, b
+    c := a + b
+    WRITE c
+END
+```
+
+## Language summary
+
+- `READ` a list of variables from input.
+- `WRITE` a list of expressions to output.
+- Assignment with `:=`.
+- Integer arithmetic.
+
+## File extension and runtime
+
+Tiny source files use the `.tiny` extension. Tiny programs have no runtime
+library dependency beyond the C runtime.


### PR DESCRIPTION
## What

Makes the README a leaner, install/usage-focused landing page and moves per-language detail into dedicated guides. Adds a `CONTRIBUTING.md` documenting the branch workflow.

## Approach

- **README** — trimmed to intro, system requirements, installation, and usage. The long inline `Supported Languages` section (BASIC constructs table, per-language samples) is replaced by a compact `Languages` table linking to the new guides, plus a `Contributing` section.
- **docs/languages/** — four uniform user-facing guides (`basic.md`, `col.md`, `tiny.md`, `assembunny.md`), each with the same structure: intro, example, language summary, file extension/runtime. BASIC keeps the full constructs table; COL uses the tail-recursive factorial from the real `fac.col` example.
- **CONTRIBUTING.md** — branch model (`master` release / `dev` integration), `type/description` feature-branch naming, squash-merge PR into `dev`, release-plugin flow, and the rare master-hotfix→dev case.

## Updated context

- `AGENTS.md` now notes `docs/languages/` and distinguishes the two parallel language-doc sets: `docs/languages/<lang>.md` (user-facing) vs `docs/system/<lang>-language.md` (agent-facing gotchas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)