### PR TITLE
Fix bare PRINT not emitting a newline

### DIFF
--- a/docs/system/code-generation.md
+++ b/docs/system/code-generation.md
@@ -94,6 +94,18 @@ GC emission is gated by composition, not inheritance: a `GcCodeGenerator` strate
 
 `AbstractLlvmCodeGenerator.generateDeclares` emits an ordinary `declare` for every called GC function, like any other library function; the symbols resolve at link time against `libjccbas`, where the runtime ships (linked via the single `-l<stdlib>` — there is no separate `libjccgc` library). GC functions still carry the `FunctionUtils.LIB_JCC_GC` marker, but it is now only a logical tag and affects neither declaration nor linking. The real runtime arrived in `libjccbas` 2.2.0 (`libjccbas.version` in the root `pom.xml`).
 
+## PRINT newline encoding
+
+`PrintStatement` holds the print arguments as a list encoding three source forms, and both
+backends' `PrintCodeGenerator` derive the trailing-newline flag from it identically. `PRINT x`
+is `[x]` (prints a newline). `PRINT x;` is `[x, null]` — the trailing `null`, added by
+`BasicSyntaxVisitor.visitPrintStmt`, suppresses the newline. Bare `PRINT` is the empty list `[]`
+and must still print a newline. The flag is
+`eol = expressions.isEmpty() || expressions.getLast() != null`; the earlier
+`!expressions.isEmpty() && ...` form dropped the newline for bare `PRINT` and shipped as a bug
+(issue #77). The `null` sentinel is filtered out before building the printf arguments (LLVM
+`filter(Objects::nonNull)`, FASM `removeLast()`).
+
 ## COL vals (LLVM)
 
 COL `val` declarations span semantics and codegen:

--- a/jcc-basic/src/main/java/se/dykstrom/jcc/basic/code/asm/statement/PrintCodeGenerator.java
+++ b/jcc-basic/src/main/java/se/dykstrom/jcc/basic/code/asm/statement/PrintCodeGenerator.java
@@ -46,7 +46,7 @@ public class PrintCodeGenerator extends AbstractStatementCodeGenerator<PrintStat
     public List<Line> generate(PrintStatement statement) {
         return withCodeContainer(cc -> {
             final var expressions = new ArrayList<>(statement.getExpressions());
-            final var eol = !expressions.isEmpty() && expressions.getLast() != null;
+            final var eol = expressions.isEmpty() || expressions.getLast() != null;
             if (!expressions.isEmpty() && expressions.getLast() == null) {
                 expressions.removeLast();
             }

--- a/jcc-basic/src/main/java/se/dykstrom/jcc/basic/code/llvm/statement/PrintCodeGenerator.java
+++ b/jcc-basic/src/main/java/se/dykstrom/jcc/basic/code/llvm/statement/PrintCodeGenerator.java
@@ -39,7 +39,7 @@ public record PrintCodeGenerator(LlvmCodeGenerator codeGenerator) implements Llv
     @Override
     public void toLlvm(final PrintStatement statement, final List<Line> lines, final SymbolTable symbolTable) {
         final var expressions = statement.getExpressions();
-        final var eol = !expressions.isEmpty() && expressions.getLast() != null;
+        final var eol = expressions.isEmpty() || expressions.getLast() != null;
         final var nonNullExpressions = expressions.stream().filter(Objects::nonNull).toList();
         final var opExpressions = nonNullExpressions.stream()
                 .map(e -> codeGenerator.expression(e, lines, symbolTable))

--- a/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicCodeGeneratorTests.kt
+++ b/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicCodeGeneratorTests.kt
@@ -352,6 +352,18 @@ class BasicCodeGeneratorTests : AbstractBasicCodeGeneratorTests() {
     }
 
     @Test
+    fun shouldPrintNoExpression() {
+        // Bare PRINT (empty expression list) should print a newline, see issue #77
+        val printStatement = PrintStatement(0, 0, listOf())
+
+        val result = assembleProgram(listOf(printStatement))
+        val lines = result.lines()
+
+        val fmt = lines.filterIsInstance<DataDefinition>().find { it.identifier().mappedName == "__fmt__nl" }!!
+        assertEquals("\"\",10,0", fmt.value)
+    }
+
+    @Test
     fun shouldDefineIntegerConstant() {
         val declarations = listOf(DeclarationAssignment(0, 0, "a%", I64.INSTANCE, IL_3))
         val statement = ConstDeclarationStatement(0, 0, declarations)

--- a/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicLlvmCodeGeneratorTests.kt
+++ b/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicLlvmCodeGeneratorTests.kt
@@ -170,6 +170,16 @@ internal class BasicLlvmCodeGeneratorTests : AbstractBasicCodeGeneratorTests() {
     }
 
     @Test
+    fun printNoExpression() {
+        // Bare PRINT (empty expression list) should print a newline, see issue #77
+        val result = assembleProgram(cg, listOf(PrintStatement(listOf())))
+        assertContains(result, listOf(
+            "@_.printf.fmt..nl = private constant [2 x i8] c\"\\0A\\00\"", // Newline only
+            "%0 = call i32 (ptr, ...) @printf(ptr @_.printf.fmt..nl)"),
+        )
+    }
+
+    @Test
     fun printTwoLiterals() {
         val result = assembleProgram(cg, listOf(PrintStatement(listOf(IL_5, FL_2_0))))
         assertContains(result, listOf("%0 = call i32 (ptr, ...) @printf(ptr @_.printf.fmt.I64.F64.nl, i64 5, double 2.0)"))

--- a/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/BasicLlvmCompileAndRunIT.kt
+++ b/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/BasicLlvmCompileAndRunIT.kt
@@ -63,6 +63,24 @@ class BasicLlvmCompileAndRunIT : AbstractIntegrationTests() {
     }
 
     @Test
+    fun shouldPrintBlankLine() {
+        // A bare PRINT should output a blank line, see issue #77
+        compileAndRunLlvm(
+            BASIC,
+            listOf(
+                "PRINT 1",
+                "PRINT",
+                "PRINT 2",
+            ),
+            listOf(
+                "1",
+                "",
+                "2",
+            ),
+        )
+    }
+
+    @Test
     fun shouldPrintArithmeticIntExpressions() {
         val source = listOf(
             "PRINT 8 + 7",


### PR DESCRIPTION
## What

Fixes #77 — a bare `PRINT` (no arguments) on the LLVM backend printed nothing instead of a blank line. `PRINT 1` / `PRINT` / `PRINT 2` produced `1\n2\n` rather than `1\n\n2\n`.

## Approach

Both `PrintCodeGenerator`s (FASM and LLVM) derived the trailing-newline flag with `!expressions.isEmpty() && expressions.getLast() != null`, which is `false` for the empty expression list a bare `PRINT` produces — so no newline was emitted. This was a regression introduced with the LLVM backend; the FASM generator carried the same latent defect.

The guard is inverted to `expressions.isEmpty() || expressions.getLast() != null`, which keeps `PRINT x` (newline) and `PRINT x;` (no newline) correct while restoring the newline for bare `PRINT`. Fixed in both backends.

Tests added:
- LLVM and FASM codegen unit tests asserting a bare `PRINT` emits a newline-only format string.
- `BasicLlvmCompileAndRunIT.shouldPrintBlankLine` — compiles and runs the exact issue program, asserting the blank line.

Verified: `BasicCodeGeneratorTests` (74) and `BasicLlvmCodeGeneratorTests` (36) pass; `BasicLlvmCompileAndRunIT` (38) passes under `-P llvm-tests`; manual run confirms `1`, blank line, `2`.

## Updated context

Added a "PRINT newline encoding" section to `docs/system/code-generation.md` documenting the tri-state `PrintStatement` argument-list encoding and the shared `eol` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)