### PR TITLE
Fix incorrect unused-variable warnings with user-defined functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 
 JCC (Johan Compiler Collection) is a multi-module compiler infrastructure for compiling four toy languages — BASIC, Tiny, Assembunny, and COL — to native executables. It has two fully supported backends: FASM (Flat Assembler) for x86-64 assembly and an LLVM IR backend (via external Clang). Built with ANTLR4 for parsing; implemented in Java 21 and Kotlin.
 
+Before creating a branch or opening a PR, read [CONTRIBUTING.md](CONTRIBUTING.md) for the branch conventions: branch off `dev`, name it `type/short-description` (e.g. `fix/...`), and squash-merge into `dev`.
+
 ## Stack
 
 | Piece | Choice |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 JCC (Johan Compiler Collection) is a multi-module compiler infrastructure for compiling four toy languages — BASIC, Tiny, Assembunny, and COL — to native executables. It has two fully supported backends: FASM (Flat Assembler) for x86-64 assembly and an LLVM IR backend (via external Clang). Built with ANTLR4 for parsing; implemented in Java 21 and Kotlin.
 
-Before creating a branch or opening a PR, read [CONTRIBUTING.md](CONTRIBUTING.md) for the branch conventions: branch off `dev`, name it `type/short-description` (e.g. `fix/...`), and squash-merge into `dev`.
+Before creating a branch or opening a PR, read [CONTRIBUTING.md](CONTRIBUTING.md) for the branch conventions.
 
 ## Stack
 

--- a/docs/system/unused-variable-warnings.md
+++ b/docs/system/unused-variable-warnings.md
@@ -1,0 +1,34 @@
+# Unused-variable warnings
+
+Unused-variable warnings for BASIC and COL are produced by the shared
+`VariableUsageTracker` (`jcc-base`, `se.dykstrom.jcc.common.semantics`). It is keyed by
+variable name only — two sets, `declaredVariables` and `usedVariables`, with no type or
+scope awareness. `declare(name, node)` records a declaration, `use(name)` a usage, and
+`check(...)` reports every declared name not in the used set.
+
+Each language's top-level semantics parser calls the no-arg `check(...)` once, after the
+whole program is parsed (`BasicSemanticsParser.parse`, `ColSemanticsParser.parse`). This
+top-level pass is the sole authority on global variables, because only then are all usages
+known.
+
+User-defined functions emulate a nested scope with a save/restore protocol in the
+function-definition parser (`BasicSemanticsParser.functionDefinitionStatement`,
+`FunDefPass2SemanticsParser.parse`): `save()`, declare each parameter, parse the body, then
+`check(parameterNames, ...)`, then `restore(parameterNames)`.
+
+The per-function check MUST use the name-restricted overload
+`check(Set<String> names, ...)` with the function's parameter names — never the no-arg
+`check()`. The no-arg form inspects every declared name still live in scope, including
+globals, and a global used only later in source order has not been recorded as used yet, so
+it is wrongly flagged (issue #78). Scoping the check to parameters flags only genuinely
+unused parameters and leaves globals to the top-level pass.
+
+`restore(parameterNames)` propagates usages of non-parameter names (globals used inside the
+function) out to the enclosing scope while discarding parameter-name usages. Because the
+tracker is name-keyed, a global shadowed by a same-named parameter does not inherit the
+parameter's usage.
+
+Note the two languages differ on where a global can be used: BASIC globals may be used
+inside functions, whereas COL top-level vals are not visible in function bodies (referencing
+one there is an "undefined variable" error), so a COL val can only be used in the main
+program.

--- a/jcc-base/src/main/java/se/dykstrom/jcc/common/semantics/VariableUsageTracker.java
+++ b/jcc-base/src/main/java/se/dykstrom/jcc/common/semantics/VariableUsageTracker.java
@@ -42,6 +42,19 @@ public class VariableUsageTracker {
     }
 
     /**
+     * Checks for unused variables among the given names only, and reports warnings for any that
+     * were declared but never used. Used to check a function's own parameters without touching
+     * enclosing (global) variables, which are checked at the top level once all usages are known.
+     */
+    public void check(final Set<String> names, final BiConsumer<Node, String> warningsReporter) {
+        declaredVariables.forEach((name, node) -> {
+            if (names.contains(name) && !usedVariables.contains(name)) {
+                warningsReporter.accept(node, "unused variable: " + name);
+            }
+        });
+    }
+
+    /**
      * Saves the current state of the tracker before parsing a function.
      */
     public void save() {

--- a/jcc-base/src/test/kotlin/se/dykstrom/jcc/common/semantics/VariableUsageTrackerTests.kt
+++ b/jcc-base/src/test/kotlin/se/dykstrom/jcc/common/semantics/VariableUsageTrackerTests.kt
@@ -112,6 +112,35 @@ class VariableUsageTrackerTests {
     }
 
     @Test
+    fun `should only check the given names when a name set is supplied`() {
+        // Given: a global 'x' (unused) and a parameter 'y' (used) live in the same scope
+        tracker.declare("x", Declaration("x", I32.INSTANCE))
+        tracker.declare("y", Declaration("y", I32.INSTANCE))
+        tracker.use("y")
+
+        // When: we check only the parameter names
+        tracker.check(setOf("y")) { _, msg -> warnings.add(msg) }
+
+        // Then: the global 'x' is not reported, even though it is unused so far (issue #78)
+        assertTrue(warnings.isEmpty())
+    }
+
+    @Test
+    fun `should report an unused name that is in the given name set`() {
+        // Given
+        tracker.declare("x", Declaration("x", I32.INSTANCE))
+        tracker.declare("y", Declaration("y", I32.INSTANCE))
+        tracker.use("y")
+
+        // When: 'x' is included in the checked names
+        tracker.check(setOf("x")) { _, msg -> warnings.add(msg) }
+
+        // Then
+        assertEquals(1, warnings.size)
+        assertEquals("unused variable: x", warnings[0])
+    }
+
+    @Test
     fun `should track nested usages correctly`() {
         // Scenario:
         // Global: 'a' (unused), 'b' (used in func)

--- a/jcc-basic/src/main/java/se/dykstrom/jcc/basic/compiler/BasicSemanticsParser.java
+++ b/jcc-basic/src/main/java/se/dykstrom/jcc/basic/compiler/BasicSemanticsParser.java
@@ -409,8 +409,8 @@ public class BasicSemanticsParser extends AbstractSemanticsParser<BasicTypeManag
 
             // Check and update expression
             var expression = expression(statement.expression());
-            // Check for unused parameters
-            usageTracker.check((n, m) -> reportWarning(n, m, UNUSED_VARIABLE));
+            // Check for unused parameters (globals are checked at the top level, issue #78)
+            usageTracker.check(parameterNames, (n, m) -> reportWarning(n, m, UNUSED_VARIABLE));
             // Restore tracking state
             usageTracker.restore(parameterNames);
 

--- a/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicSemanticsParserTests.kt
+++ b/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicSemanticsParserTests.kt
@@ -565,6 +565,14 @@ class BasicSemanticsParserTests : AbstractBasicSemanticsParserTests() {
     }
 
     @Test
+    fun shouldNotWarnAboutGlobalUsedInMainProgramWithFunction() {
+        // Issue #78: global x is used in the main program after a function definition;
+        // it must not be reported unused just because it is not used inside the function.
+        parse("DIM x AS INTEGER : DEF FNfoo%(y AS INTEGER) = y : LET x = 7 : PRINT FNfoo%(x)")
+        assertTrue(errorListener.warnings.isEmpty())
+    }
+
+    @Test
     fun testAssignment() {
         parse("10 let a = 5")
         parse("20 b = 5")

--- a/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/FunDefPass2SemanticsParser.java
+++ b/jcc-col/src/main/java/se/dykstrom/jcc/col/semantics/statement/FunDefPass2SemanticsParser.java
@@ -87,8 +87,8 @@ public class FunDefPass2SemanticsParser<T extends TypeManager> extends AbstractS
 
             // Check and update expression
             final var expression = parser.expression(statement.expression());
-            // Check for unused parameters
-            usageTracker.check((n, m) -> reportWarning(n, m, UNUSED_VARIABLE));
+            // Check for unused parameters (globals are checked at the top level, issue #78)
+            usageTracker.check(parameterNames, (n, m) -> reportWarning(n, m, UNUSED_VARIABLE));
             // Restore tracking state
             usageTracker.restore(parameterNames);
 

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserValTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserValTests.kt
@@ -18,6 +18,7 @@
 package se.dykstrom.jcc.col.compiler
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import se.dykstrom.jcc.col.ColTests.Companion.FUN_I64_TO_I64
 import se.dykstrom.jcc.col.ast.statement.ValDeclarationStatement
@@ -156,6 +157,20 @@ class ColSemanticsParserValTests : AbstractColSemanticsParserTests() {
     @Test
     fun shouldWarnAboutUnusedVal() {
         parseAndExpectWarning("val a := 17", "unused variable: a", UNUSED_VARIABLE)
+    }
+
+    @Test
+    fun shouldNotWarnAboutValUsedOnlyAfterFunctionDefinition() {
+        // Issue #78: top-level val x is used after a function definition; it must not be
+        // reported unused just because it is not used inside the function.
+        parse(
+            """
+            val x := 17
+            fun foo(y as i64) -> i64 := y
+            call println(x)
+            """.trimIndent()
+        )
+        assertTrue(errorListener.warnings.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## What

Fixes #78. A global variable used only in the main program was wrongly reported as `unused variable` when the program also defined a user-defined function, e.g.:

```quickbasic
DIM x AS INTEGER
DEF FNfoo%(y AS INTEGER) = y
LET x = 7
PRINT FNfoo%(x)
```
previously warned `unused variable: x` under `-Wall`.

## Approach

The per-function unused-variable check ran the shared `VariableUsageTracker.check(...)` over *all* in-scope names, so a global not yet used at the point of the function definition (in source order) was flagged prematurely — even though the top-level check later saw it as used.

- Add a name-restricted overload `VariableUsageTracker.check(Set<String> names, ...)` that inspects only the given names.
- Call it with the function's `parameterNames` in both `BasicSemanticsParser` (DEF FN) and COL's `FunDefPass2SemanticsParser`, which shared the identical defect. Globals remain the responsibility of the top-level check, run once all usages are known.

## Updated context

- Tests: tracker unit tests for the new overload; BASIC and COL regression tests reproducing the issue (verified red before the fix, green after). Existing unused/shadowing tests unchanged.
- Docs: added `docs/system/unused-variable-warnings.md` describing the shared tracker mechanism and the per-function `save`/`check(parameterNames)`/`restore` protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)