### PR TITLE
Make LLVM the default backend and deprecate FASM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## What is this
 
-JCC (Johan Compiler Collection) is a multi-module compiler infrastructure for compiling four toy languages — BASIC, Tiny, Assembunny, and COL — to native executables. It has two fully supported backends: FASM (Flat Assembler) for x86-64 assembly and an LLVM IR backend (via external Clang). Built with ANTLR4 for parsing; implemented in Java 21 and Kotlin.
+JCC (Johan Compiler Collection) is a multi-module compiler infrastructure for compiling four toy languages — BASIC, Tiny, Assembunny, and COL — to native executables. It has two backends: an LLVM IR backend (via external Clang), which is the default, and FASM (Flat Assembler) for x86-64 assembly, which is deprecated and will be removed in a future release (select it with `--backend FASM`). Built with ANTLR4 for parsing; implemented in Java 21 and Kotlin.
 
 Before creating a branch or opening a PR, read [CONTRIBUTING.md](CONTRIBUTING.md) for the branch conventions.
 
@@ -14,7 +14,7 @@ Before creating a branch or opening a PR, read [CONTRIBUTING.md](CONTRIBUTING.md
 | Build | Maven (multi-module) |
 | Parsing | ANTLR4 |
 | CLI parsing | JCommander |
-| Backends | FASM (x86-64 assembly, Windows-only); LLVM IR (via external Clang) |
+| Backends | LLVM IR (via external Clang, default); FASM (x86-64 assembly, Windows-only, deprecated) |
 | Runtime libs | `msvcrt.dll`, `libjccbas.dll` (FASM backend); `libjccbas.a` (BASIC), `libjcccol.a` (COL), plus `-lm` on Linux (LLVM backend) |
 | Testing | JUnit 5 |
 
@@ -66,7 +66,8 @@ For Java symbol navigation (go-to-definition, find-references, hover) and type/i
 
 ## Gotchas
 
-- Only `fasm.exe` (assembling and running the output) is Windows-only; FASM *code generation* runs on any platform. Reproduce FASM codegen bugs off Windows with `java -jar jcc-compiler/target/jcc-compiler-*.jar -S program.bas`, which writes the `.asm` and stops before assembling. The FASM backend is slated for future deprecation in favor of the LLVM backend.
+- LLVM is the default backend; the FASM backend is deprecated and requires an explicit `--backend FASM` (which also prints a deprecation warning to stdout). Note `-S program.bas` now emits LLVM IR (`.ll`) by default — add `--backend FASM` to write FASM `.asm` instead.
+- Only `fasm.exe` (assembling and running the output) is Windows-only; FASM *code generation* runs on any platform. Reproduce FASM codegen bugs off Windows with `java -jar jcc-compiler/target/jcc-compiler-*.jar --backend FASM -S program.bas`, which writes the `.asm` and stops before assembling.
 - FASM compile-and-run ITs (`*CompileAndRunIT`) are annotated `@EnabledOnOs(OS.WINDOWS)` — they need `fasm.exe` to assemble and run, so they are silently skipped everywhere else. A change that breaks FASM compilation (e.g. a shared-semantics tightening) therefore passes a local `mvn verify` and the Linux/macOS CI legs; only the Windows CI leg catches it. The LLVM ITs (`*LlvmCompileAndRunIT`) are not OS-gated.
 - The LLVM backend is fully supported across all four languages (BASIC, Tiny, Assembunny, COL). A few narrow BASIC gaps remain (e.g. `SLEEP` has no LLVM IT; `LINE INPUT;` `inhibitNewline` has no effect) — see `docs/system/standard-libraries.md`.
 - Integration tests in `jcc-compiler` compile via the test classpath, resolved from the local Maven repo — after changing another module, refresh the repo before running ITs or they exercise stale code. The only refresh observed to be reliable is `mvn clean install -DskipTests`: both `-pl jcc-compiler -am` and an incremental `mvn -pl <module> -am install` have produced jars missing changes that compiled minutes earlier. Manual `java -jar` runs additionally need the `dependency:copy-dependencies` refresh from Commands (and again after every `clean`). Stale jars show up as phantom failures: fixes that don't take effect, or ITs failing on features that exist in source.

--- a/README.md
+++ b/README.md
@@ -16,29 +16,29 @@ JCC, the Johan Compiler Collection, is a collection of toy compilers built with
 [Tiny](docs/languages/tiny.md), and [Assembunny](docs/languages/assembunny.md) —
 to native executables.
 
-JCC has two fully supported backends: [flat assembler](http://flatassembler.net)
-(FASM), which emits x86-64 assembly, and [LLVM](docs/LLVM.md), which emits LLVM IR
-compiled by Clang. The FASM backend is the default; select the LLVM backend with
-`--backend LLVM`.
+JCC has two backends: [LLVM](docs/LLVM.md), which emits LLVM IR compiled by Clang,
+and [flat assembler](http://flatassembler.net) (FASM), which emits x86-64 assembly.
+The LLVM backend is the default. The FASM backend is deprecated and will be removed
+in a future release; select it with `--backend FASM`.
 
 ## System Requirements
 
 The requirements depend on which backend you use.
 
-### FASM backend (default)
-
-* Windows
-* Java 21+
-
-Executables created with the FASM backend depend on the library [msvcrt.dll](https://en.wikipedia.org/wiki/Microsoft_Windows_library_files), which is a part of Windows. BASIC executables also depend on the BASIC standard library, libjccbas.dll, that is distributed together with JCC.
-
-### LLVM backend
+### LLVM backend (default)
 
 * Windows, Linux, or macOS
 * Java 21+
 * Clang 20+
 
 The LLVM backend works on Windows, Linux, and macOS, but it is not bundled with JCC: you need to install [Clang](https://clang.llvm.org) (version 20 or later) yourself. See [Using LLVM as Backend](docs/LLVM.md) for installation instructions. BASIC and COL executables depend on the static standard libraries libjccbas.a and libjcccol.a respectively, which are distributed together with JCC.
+
+### FASM backend (deprecated)
+
+* Windows
+* Java 21+
+
+Executables created with the FASM backend depend on the library [msvcrt.dll](https://en.wikipedia.org/wiki/Microsoft_Windows_library_files), which is a part of Windows. BASIC executables also depend on the BASIC standard library, libjccbas.dll, that is distributed together with JCC.
 
 You can download the Java runtime from [Adoptium](https://adoptium.net).
 
@@ -72,8 +72,8 @@ This will print a message similar to this:
 Usage: jcc [options] <source file>
   Options:
     --backend
-      Generate code for <backend>
-      Default: FASM
+      Generate code for <backend>. The FASM backend is deprecated
+      Default: LLVM
       Possible Values: [FASM, LLVM]
     --help
       Show this help text
@@ -123,7 +123,7 @@ Usage: jcc [options] <source file>
       Default: false
 ```
 
-By default JCC uses the FASM backend. To compile with the LLVM backend instead, add `--backend LLVM`; see [Using LLVM as Backend](docs/LLVM.md) for details.
+By default JCC uses the LLVM backend; see [Using LLVM as Backend](docs/LLVM.md) for details. The FASM backend is deprecated and will be removed in a future release; select it with `--backend FASM`.
 
 ## Languages
 

--- a/docs/LLVM.md
+++ b/docs/LLVM.md
@@ -1,7 +1,8 @@
 # Using LLVM as Backend
 
-LLVM is one of JCC's two fully supported backends, alongside flat assembler (FASM). You select the
-LLVM backend using the command line argument `--backend`:
+LLVM is JCC's default backend. The other backend, flat assembler (FASM), is deprecated and will be
+removed in a future release. LLVM is used automatically; you can also select it explicitly using the
+command line argument `--backend`:
 
 ```bash
 $ jcc --backend LLVM ...

--- a/docs/languages/col.md
+++ b/docs/languages/col.md
@@ -52,6 +52,6 @@ call println(fac_iter(5))
 ## File extension and runtime
 
 COL source files use the `.col` extension. COL executables require the COL
-standard library, `libjcccol.a`, which is distributed together with JCC. COL is
-best used with the LLVM backend; the FASM backend still compiles COL but is being
-phased out.
+standard library, `libjcccol.a`, which is distributed together with JCC. COL uses
+the default LLVM backend; the FASM backend still compiles COL but is deprecated and
+will be removed in a future release.

--- a/docs/system/code-generation.md
+++ b/docs/system/code-generation.md
@@ -5,7 +5,7 @@ JCC has two code-generation backends sharing a component-based design. Each AST 
 - **FASM backend** (`jcc-base`, `AbstractCodeGenerator`): emits x86-64 Flat Assembler text. Output is a `.asm` file assembled by `FasmAssembler`. Windows-only.
 - **LLVM backend** (`jcc-llvm`, `AbstractLlvmCodeGenerator`): emits LLVM IR. Output is a `.ll` file compiled by `LlvmAssembler` (clang). Cross-platform; requires a user-installed Clang 20+.
 
-Both produce a `TargetProgram` whose `toText()` is written to the intermediate file. The backend is selected by `CompilerFactory` from the `--backend` flag (default FASM).
+Both produce a `TargetProgram` whose `toText()` is written to the intermediate file. The backend is selected by `CompilerFactory` from the `--backend` flag (default LLVM; FASM is deprecated).
 
 ## Component registration
 

--- a/jcc-compiler/src/main/java/se/dykstrom/jcc/main/Jcc.java
+++ b/jcc-compiler/src/main/java/se/dykstrom/jcc/main/Jcc.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 import static se.dykstrom.jcc.common.utils.VerboseLogger.log;
 import static se.dykstrom.jcc.main.Backend.FASM;
+import static se.dykstrom.jcc.main.Backend.LLVM;
 
 /**
  * The main class of the Johan Compiler Collection (JCC). It parses command line arguments,
@@ -51,8 +52,8 @@ public class Jcc {
 
     private final String[] args;
 
-    @Parameter(names = "--backend", description = "Generate code for <backend>")
-    private Backend backend = FASM;
+    @Parameter(names = "--backend", description = "Generate code for <backend>. The FASM backend is deprecated")
+    private Backend backend = LLVM;
 
     @Parameter(names = "-assembler", description = "Use <assembler> as the backend assembler. Default: 'fasm' for the FASM backend, and 'clang' for the LLVM backend")
     private String assemblerExecutable;
@@ -129,6 +130,10 @@ public class Jcc {
         } catch (ParameterException pe) {
             System.err.println(PROGRAM + ": " + pe.getMessage());
             return 1;
+        }
+
+        if (backend == FASM) {
+            System.out.println(PROGRAM + ": warning: the FASM backend is deprecated and will be removed in a future release; the default backend is now LLVM");
         }
 
         setUpOptions();

--- a/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/AbstractIntegrationTests.kt
+++ b/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/AbstractIntegrationTests.kt
@@ -37,6 +37,8 @@ abstract class AbstractIntegrationTests {
         const val ASM = "asm"
         const val EXE = "exe"
 
+        private const val BACKEND_OPTION = "--backend"
+        private const val BACKEND_VALUE = "FASM"
         private const val ASM_OPTION = "-assembler"
         private const val ASM_VALUE = "../fasm/FASM.EXE"
         private const val ASM_INC_OPTION = "-assembler-include"
@@ -60,6 +62,8 @@ abstract class AbstractIntegrationTests {
          */
         fun buildCommandLine(sourceFilename: String, vararg otherArgs: String): Array<String> {
             val args = ArrayList<String>()
+            args.add(BACKEND_OPTION)
+            args.add(BACKEND_VALUE)
             args.add(ASM_OPTION)
             args.add(ASM_VALUE)
             args.add(ASM_INC_OPTION)

--- a/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/JccTests.kt
+++ b/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/JccTests.kt
@@ -220,8 +220,8 @@ class JccTests {
 
     @Test
     fun shouldCompileButNotAssemble() {
-        // Given
-        val (sourcePath, asmPath) = createSourceFile("PRINT")
+        // Given: no --backend, so the default (LLVM) backend is used, emitting an .ll file
+        val (sourcePath, llvmPath) = createSourceFile("PRINT", outputExt = "ll")
         val args = arrayOf("-S", sourcePath.toString())
 
         // When
@@ -229,7 +229,37 @@ class JccTests {
 
         // Then
         assertEquals(0, returnCode)
-        assertTrue(Files.exists(asmPath), "asm file not found: $asmPath")
+        assertTrue(Files.exists(llvmPath), "LLVM IR file not found: $llvmPath")
+    }
+
+    @Test
+    fun shouldPrintDeprecationWarningForFasmBackend() {
+        // Given
+        val (sourcePath, _) = createSourceFile("PRINT")
+        val args = arrayOf("-S", "--backend", "FASM", sourcePath.toString())
+
+        // When
+        val output = tapSystemOut {
+            assertEquals(0, Jcc(args).run())
+        }
+
+        // Then
+        assertTrue(output.contains("jcc: warning: the FASM backend is deprecated"))
+    }
+
+    @Test
+    fun shouldNotPrintDeprecationWarningForDefaultBackend() {
+        // Given
+        val (sourcePath, _) = createSourceFile("PRINT")
+        val args = arrayOf("-S", sourcePath.toString())
+
+        // When
+        val output = tapSystemOut {
+            assertEquals(0, Jcc(args).run())
+        }
+
+        // Then
+        assertFalse(output.contains("deprecated"))
     }
 
     private fun createSourceFile(text: String, sourceExt: String = "bas", outputExt: String = "asm"): Pair<Path, Path> {

--- a/regression_test
+++ b/regression_test
@@ -66,8 +66,8 @@ EXIT_CODE=0
 # For each BASIC file, compile it and compare it to the pre-compiled file
 for BAS_FILE in *.bas
 do
-    # Compile BASIC file
-    if ! "$JCC" -S "$BAS_FILE"; then
+    # Compile BASIC file (FASM backend: this test diffs FASM assembly)
+    if ! "$JCC" --backend FASM -S "$BAS_FILE"; then
         EXIT_CODE=2
         continue
     fi


### PR DESCRIPTION
## What is this

The LLVM backend is now fully supported across all four languages (BASIC, Tiny, Assembunny, COL), so it becomes the default. The FASM backend is deprecated and will be removed in a future release. Using FASM now requires an explicit `--backend FASM` and prints a deprecation warning.

## Approach

- **Default flip lives in the CLI:** `Jcc`'s `--backend` now defaults to `LLVM`; `CompilerFactory` is unchanged (it already takes the backend explicitly).
- **Deprecation notice to stdout:** selecting FASM prints a one-line warning, as specified, rather than stderr where other diagnostics go.
- **FASM stays covered:** `buildCommandLine` (all FASM ITs) and `regression_test` now pass `--backend FASM` explicitly, so FASM codegen keeps being exercised while it exists.
- **Not removed:** FASM code generation and the bundled `fasm/` binary are untouched — this is a default change plus deprecation, not a removal.

## Risks / follow-ups

- **Windows CI is the real gate for FASM:** the FASM compile-and-run ITs are `@EnabledOnOs(WINDOWS)` and skip locally. Verify the Windows leg is green — the `--backend FASM` added to `buildCommandLine` only exercises there.
- **`-S` output changed:** any external script relying on `jcc -S` producing `.asm` now gets `.ll` unless it adds `--backend FASM`.

## Updated context

- Docs: `README.md` — reordered backend sections; LLVM is default, FASM deprecated; usage block shows `Default: LLVM`.
- Docs: `AGENTS.md` — backends row and gotchas updated; note that `-S` now emits `.ll` by default.
- Docs: `docs/LLVM.md`, `docs/languages/col.md`, `docs/system/code-generation.md` — default/deprecation wording aligned.

## How to verify

- `java -jar jcc-compiler/target/jcc-compiler-*.jar -S prog.bas` → produces `prog.ll`, no warning.
- `java -jar ... --backend FASM -S prog.bas` → produces `prog.asm` and prints `jcc: warning: the FASM backend is deprecated ...` to stdout.
