### PR TITLE
Fix BASIC operator precedence to match QuickBASIC 4.5

### DIFF
--- a/docs/languages/basic.md
+++ b/docs/languages/basic.md
@@ -123,6 +123,34 @@ The table below lists the BASIC constructs implemented so far.
 Note that BASIC keywords are case-insensitive, but built-in function names must be
 written in lowercase.
 
+## Operator precedence
+
+When several operators appear in one expression, they are applied in the order
+below (following QuickBASIC 4.5). Operators higher in the table bind tighter;
+use parentheses to override. Operators on the same row share a precedence level
+and are evaluated left to right.
+
+| Precedence | Operators | Category |
+|:----------:|-----------|----------|
+| highest    | `( )`     | Grouping |
+|            | `^`       | Exponentiation |
+|            | `-`       | Negation (unary minus) |
+|            | `*` `/`   | Multiplication, division |
+|            | `\`       | Integer division |
+|            | `MOD`     | Modulo |
+|            | `+` `-`   | Addition, subtraction |
+|            | `=` `<>` `>` `>=` `<` `<=` | Relational |
+|            | `NOT`     | Bitwise NOT |
+|            | `AND`     | Bitwise AND |
+|            | `OR`      | Bitwise OR |
+|            | `XOR`     | Bitwise XOR |
+|            | `EQV`     | Bitwise EQV |
+| lowest     | `IMP`     | Bitwise IMP |
+
+For example, `10 MOD 4 \ 2` is `10 MOD (4 \ 2)` = 0, and `a XOR b OR c` is
+`a XOR (b OR c)`. Relational operators are left-associative and may be chained:
+`1 = 2 = 3` parses as `(1 = 2) = 3`.
+
 ## File extension and runtime
 
 BASIC source files use the `.bas` extension. BASIC executables require the BASIC

--- a/docs/system/basic-language.md
+++ b/docs/system/basic-language.md
@@ -18,3 +18,19 @@ test writes built-in calls in lowercase; follow that.
 QuickBASIC's `FOR ... NEXT` is not implemented — `Basic.g4` has no rule for it and
 a `FOR` line fails to parse. Use `WHILE ... WEND` for counted loops (the idiom in
 every BASIC integration test).
+
+## Operator precedence is one-level-per-rule
+
+The expression grammar is a layered cascade — `expr → impExpr → eqvExpr → xorExpr
+→ orExpr → andExpr → notExpr → relExpr → addSubExpr → modExpr → iDivExpr →
+mulDivExpr → factor`. Precedence comes *only* from this layering: every binary
+operator sits in its own rule whose right operand is the next-tighter rule, so
+one rule = one precedence level. The user-facing order is in
+`docs/languages/basic.md`; it matches QuickBASIC 4.5.
+
+Do **not** collapse operators of different precedence into one rule (e.g. putting
+`* / \ MOD` together, or `OR XOR EQV IMP` together). Same-rule operators become
+one level, and the bug is latent: left-to-right examples like `5 * 10 \ 2` read
+the same either way — it only shows when the weaker operator comes first
+(`10 \ 4 * 2`, `a XOR b OR c`). `BasicSyntaxVisitorTests` guards the divergent
+cases; keep a weaker-operator-first test for any new precedence level.

--- a/jcc-basic/src/main/antlr4/se/dykstrom/jcc/basic/compiler/Basic.g4
+++ b/jcc-basic/src/main/antlr4/se/dykstrom/jcc/basic/compiler/Basic.g4
@@ -250,14 +250,26 @@ whileStmt
 /* Expressions */
 
 expr
-   : orExpr
+   : impExpr
+   ;
+
+impExpr
+   : impExpr IMP eqvExpr
+   | eqvExpr
+   ;
+
+eqvExpr
+   : eqvExpr EQV xorExpr
+   | xorExpr
+   ;
+
+xorExpr
+   : xorExpr XOR orExpr
+   | orExpr
    ;
 
 orExpr
    : orExpr OR andExpr
-   | orExpr XOR andExpr
-   | orExpr EQV andExpr
-   | orExpr IMP andExpr
    | andExpr
    ;
 
@@ -272,26 +284,34 @@ notExpr
    ;
 
 relExpr
-   : addSubExpr EQ addSubExpr
-   | addSubExpr GE addSubExpr
-   | addSubExpr GT addSubExpr
-   | addSubExpr LE addSubExpr
-   | addSubExpr LT addSubExpr
-   | addSubExpr NE addSubExpr
+   : relExpr EQ addSubExpr
+   | relExpr GE addSubExpr
+   | relExpr GT addSubExpr
+   | relExpr LE addSubExpr
+   | relExpr LT addSubExpr
+   | relExpr NE addSubExpr
    | addSubExpr
    ;
 
 addSubExpr
-   : addSubExpr PLUS term
-   | addSubExpr MINUS term
-   | term
+   : addSubExpr PLUS modExpr
+   | addSubExpr MINUS modExpr
+   | modExpr
    ;
 
-term
-   : term STAR factor
-   | term SLASH factor
-   | term BACKSLASH factor
-   | term MOD factor
+modExpr
+   : modExpr MOD iDivExpr
+   | iDivExpr
+   ;
+
+iDivExpr
+   : iDivExpr BACKSLASH mulDivExpr
+   | mulDivExpr
+   ;
+
+mulDivExpr
+   : mulDivExpr STAR factor
+   | mulDivExpr SLASH factor
    | factor
    ;
 

--- a/jcc-basic/src/main/java/se/dykstrom/jcc/basic/compiler/BasicSyntaxVisitor.java
+++ b/jcc-basic/src/main/java/se/dykstrom/jcc/basic/compiler/BasicSyntaxVisitor.java
@@ -639,6 +639,45 @@ public class BasicSyntaxVisitor extends BasicBaseVisitor<Node> {
     // Expressions:
     
     @Override
+    public Node visitImpExpr(ImpExprContext ctx) {
+        if (ctx.getChildCount() == 1) {
+            return visitChildren(ctx);
+        } else {
+            final var line = ctx.getStart().getLine();
+            final var column = ctx.getStart().getCharPositionInLine();
+            final var left = (Expression) ctx.impExpr().accept(this);
+            final var right = (Expression) ctx.eqvExpr().accept(this);
+            return new ImpExpression(line, column, left, right);
+        }
+    }
+
+    @Override
+    public Node visitEqvExpr(EqvExprContext ctx) {
+        if (ctx.getChildCount() == 1) {
+            return visitChildren(ctx);
+        } else {
+            final var line = ctx.getStart().getLine();
+            final var column = ctx.getStart().getCharPositionInLine();
+            final var left = (Expression) ctx.eqvExpr().accept(this);
+            final var right = (Expression) ctx.xorExpr().accept(this);
+            return new EqvExpression(line, column, left, right);
+        }
+    }
+
+    @Override
+    public Node visitXorExpr(XorExprContext ctx) {
+        if (ctx.getChildCount() == 1) {
+            return visitChildren(ctx);
+        } else {
+            final var line = ctx.getStart().getLine();
+            final var column = ctx.getStart().getCharPositionInLine();
+            final var left = (Expression) ctx.xorExpr().accept(this);
+            final var right = (Expression) ctx.orExpr().accept(this);
+            return new XorExpression(line, column, left, right);
+        }
+    }
+
+    @Override
     public Node visitOrExpr(OrExprContext ctx) {
         if (ctx.getChildCount() == 1) {
             return visitChildren(ctx);
@@ -647,16 +686,7 @@ public class BasicSyntaxVisitor extends BasicBaseVisitor<Node> {
             final var column = ctx.getStart().getCharPositionInLine();
             final var left = (Expression) ctx.orExpr().accept(this);
             final var right = (Expression) ctx.andExpr().accept(this);
-
-            if (isValid(ctx.EQV())) {
-                return new EqvExpression(line, column, left, right);
-            } else if (isValid(ctx.IMP())) {
-                return new ImpExpression(line, column, left, right);
-            } else if (isValid(ctx.OR())) {
-                return new OrExpression(line, column, left, right);
-            } else { // ctx.XOR()
-                return new XorExpression(line, column, left, right);
-            }
+            return new OrExpression(line, column, left, right);
         }
     }
 
@@ -693,8 +723,8 @@ public class BasicSyntaxVisitor extends BasicBaseVisitor<Node> {
         } else {
             int line = ctx.getStart().getLine();
             int column = ctx.getStart().getCharPositionInLine();
-            Expression left = (Expression) ctx.addSubExpr(0).accept(this);
-            Expression right = (Expression) ctx.addSubExpr(1).accept(this);
+            Expression left = (Expression) ctx.relExpr().accept(this);
+            Expression right = (Expression) ctx.addSubExpr().accept(this);
 
             if (isValid(ctx.EQ())) {
                 return new EqualExpression(line, column, left, right);
@@ -721,7 +751,7 @@ public class BasicSyntaxVisitor extends BasicBaseVisitor<Node> {
             int line = ctx.getStart().getLine();
             int column = ctx.getStart().getCharPositionInLine();
             Expression left = (Expression) ctx.addSubExpr().accept(this);
-            Expression right = (Expression) ctx.term().accept(this);
+            Expression right = (Expression) ctx.modExpr().accept(this);
 
             if (isValid(ctx.PLUS())) {
                 expr = new AddExpression(line, column, left, right);
@@ -733,23 +763,45 @@ public class BasicSyntaxVisitor extends BasicBaseVisitor<Node> {
     }
 
     @Override
-    public Node visitTerm(TermContext ctx) {
+    public Node visitModExpr(ModExprContext ctx) {
         if (ctx.getChildCount() == 1) {
             return visitChildren(ctx);
         } else {
             final var line = ctx.getStart().getLine();
             final var column = ctx.getStart().getCharPositionInLine();
-            final var left = (Expression) ctx.term().accept(this);
+            final var left = (Expression) ctx.modExpr().accept(this);
+            final var right = (Expression) ctx.iDivExpr().accept(this);
+            return new ModExpression(line, column, left, right);
+        }
+    }
+
+    @Override
+    public Node visitIDivExpr(IDivExprContext ctx) {
+        if (ctx.getChildCount() == 1) {
+            return visitChildren(ctx);
+        } else {
+            final var line = ctx.getStart().getLine();
+            final var column = ctx.getStart().getCharPositionInLine();
+            final var left = (Expression) ctx.iDivExpr().accept(this);
+            final var right = (Expression) ctx.mulDivExpr().accept(this);
+            return new IDivExpression(line, column, left, right);
+        }
+    }
+
+    @Override
+    public Node visitMulDivExpr(MulDivExprContext ctx) {
+        if (ctx.getChildCount() == 1) {
+            return visitChildren(ctx);
+        } else {
+            final var line = ctx.getStart().getLine();
+            final var column = ctx.getStart().getCharPositionInLine();
+            final var left = (Expression) ctx.mulDivExpr().accept(this);
             final var right = (Expression) ctx.factor().accept(this);
 
             if (isValid(ctx.STAR())) {
                 return new MulExpression(line, column, left, right);
-            } else if (isValid(ctx.SLASH())) {
+            } else { // ctx.SLASH()
                 return new DivExpression(line, column, left, right);
-            } else if (isValid(ctx.BACKSLASH())) {
-                return new IDivExpression(line, column, left, right);
-            } else {
-                return new ModExpression(line, column, left, right);
             }
         }
     }

--- a/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicSyntaxVisitorTests.kt
+++ b/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicSyntaxVisitorTests.kt
@@ -45,6 +45,8 @@ import se.dykstrom.jcc.basic.BasicTests.Companion.INE_STR_S
 import se.dykstrom.jcc.basic.BasicTests.Companion.SL_A
 import se.dykstrom.jcc.basic.BasicTests.Companion.SL_B
 import se.dykstrom.jcc.basic.BasicTests.Companion.SL_C
+import se.dykstrom.jcc.basic.ast.expression.EqvExpression
+import se.dykstrom.jcc.basic.ast.expression.ImpExpression
 import se.dykstrom.jcc.basic.ast.statement.*
 import se.dykstrom.jcc.common.ast.*
 import se.dykstrom.jcc.common.symbols.Scope.GLOBAL
@@ -721,6 +723,30 @@ class BasicSyntaxVisitorTests : AbstractBasicSyntaxVisitorTests() {
         testPrintOneExpression("5 * 10 \\ 2", ie)
     }
 
+    // Integer division binds looser than * and /: 10 \ 4 * 2 == 10 \ (4 * 2)
+    @Test
+    fun testIDivAndMul() {
+        val me = MulExpression(0, 0, IL_4, IL_2)
+        val ie = IDivExpression(0, 0, IL_10, me)
+        testPrintOneExpression("10 \\ 4 * 2", ie)
+    }
+
+    // MOD binds looser than integer division: 10 MOD 4 \ 2 == 10 MOD (4 \ 2)
+    @Test
+    fun testModAndIDiv() {
+        val ie = IDivExpression(0, 0, IL_4, IL_2)
+        val me = ModExpression(0, 0, IL_10, ie)
+        testPrintOneExpression("10 MOD 4 \\ 2", me)
+    }
+
+    // MOD binds looser than *: 5 MOD 4 * 2 == 5 MOD (4 * 2)
+    @Test
+    fun testModAndMul() {
+        val mul = MulExpression(0, 0, IL_4, IL_2)
+        val mod = ModExpression(0, 0, IL_5, mul)
+        testPrintOneExpression("5 MOD 4 * 2", mod)
+    }
+
     @Test
     fun testAddAndMulWithPar() {
         val ae = AddExpression(0, 0, IL_5, IL_10)
@@ -915,6 +941,49 @@ class BasicSyntaxVisitorTests : AbstractBasicSyntaxVisitorTests() {
         val e1 = EqualExpression(0, 0, IL_1, IL_2)
         val e2 = NotEqualExpression(0, 0, IL_1, IL_3)
         testPrintOneExpression("NOT 1 = 2 AND 1 <> 3", AndExpression(0, 0, NotExpression(0, 0, e1), e2))
+    }
+
+    // OR binds tighter than XOR: 1 XOR 2 OR 3 == 1 XOR (2 OR 3)
+    @Test
+    fun testXorAndOr() {
+        val or = OrExpression(0, 0, IL_2, IL_3)
+        testPrintOneExpression("1 XOR 2 OR 3", XorExpression(0, 0, IL_1, or))
+    }
+
+    // XOR binds tighter than EQV: 1 EQV 2 XOR 3 == 1 EQV (2 XOR 3)
+    @Test
+    fun testEqvAndXor() {
+        val xor = XorExpression(0, 0, IL_2, IL_3)
+        testPrintOneExpression("1 EQV 2 XOR 3", EqvExpression(0, 0, IL_1, xor))
+    }
+
+    // EQV binds tighter than IMP: 1 IMP 2 EQV 3 == 1 IMP (2 EQV 3)
+    @Test
+    fun testImpAndEqv() {
+        val eqv = EqvExpression(0, 0, IL_2, IL_3)
+        testPrintOneExpression("1 IMP 2 EQV 3", ImpExpression(0, 0, IL_1, eqv))
+    }
+
+    // Full logical cascade: 1 IMP 2 OR 3 AND 4 == 1 IMP (2 OR (3 AND 4))
+    @Test
+    fun testImpOrAnd() {
+        val and = AndExpression(0, 0, IL_3, IL_4)
+        val or = OrExpression(0, 0, IL_2, and)
+        testPrintOneExpression("1 IMP 2 OR 3 AND 4", ImpExpression(0, 0, IL_1, or))
+    }
+
+    // Relational operators are left-associative and chain: 1 = 2 = 3 == (1 = 2) = 3
+    @Test
+    fun testChainedEqual() {
+        val inner = EqualExpression(0, 0, IL_1, IL_2)
+        testPrintOneExpression("1 = 2 = 3", EqualExpression(0, 0, inner, IL_3))
+    }
+
+    // Mixed chained comparison: 5 < 4 = 1 == (5 < 4) = 1
+    @Test
+    fun testChainedLessAndEqual() {
+        val inner = LessExpression(0, 0, IL_5, IL_4)
+        testPrintOneExpression("5 < 4 = 1", EqualExpression(0, 0, inner, IL_1))
     }
 
     @Test


### PR DESCRIPTION
## What

Fixes BASIC operator precedence to follow the QuickBASIC 4.5 ordering. The expression grammar was a layered cascade where each rule defines one precedence level, but three levels were collapsed:

- `* / \ MOD` shared one level — should be `*`,`/` **>** `\` **>** `MOD`.
- `OR XOR EQV IMP` shared one level — should be `OR` **>** `XOR` **>** `EQV` **>** `IMP`.
- `relExpr` was non-associative, so chained comparisons like `a = b = c` failed to parse.

The bugs were latent because existing tests only exercised left-to-right operator order (e.g. `5 * 10 \ 2`), which reads the same under both the correct and collapsed grammars. They surface only when the weaker-binding operator comes first.

## Approach

- Re-layer `Basic.g4`: split `term` into `mulDivExpr → iDivExpr → modExpr`, split `orExpr` into `orExpr → xorExpr → eqvExpr → impExpr`, and make `relExpr` left-recursive.
- Update the matching `visit*` methods in `BasicSyntaxVisitor.java` (one method per rule). No new AST nodes and no codegen changes — existing expression nodes are reused regardless of tree shape.
- Add weaker-operator-first regression tests in `BasicSyntaxVisitorTests.kt` covering the arithmetic, logical, and relational-chaining cases.

Verified: `mvn -pl jcc-basic -am verify` → 872 tests green. End-to-end via the LLVM backend, `10 \ 4 * 2`=1, `10 MOD 4 \ 2`=0, `5 MOD 4 * 2`=5, `1 = 2 = 3`=0 — all matching QB 4.5 (and differing from the old collapsed results 4, 1, 2, and a former parse error).

## Updated context

- `docs/languages/basic.md` — new Operator precedence table (user-facing).
- `docs/system/basic-language.md` — one-level-per-rule gotcha warning against re-collapsing operators (agent-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)