### PR TITLE
Make AS optional in DIM and define undefined BASIC arrays implicitly

### DIFF
--- a/docs/Arrays.md
+++ b/docs/Arrays.md
@@ -21,6 +21,12 @@ be static, that is, they must be created when the program starts, and exist unti
 the program ends. The size of an array must also be static, defined by one or more 
 literal values or constants.
 
+In BASIC, an array that is used without having been declared is created implicitly, 
+with the inclusive upper bound 10 in every dimension. The declaration is synthesized 
+by `BasicSemanticsParser` and added to the start of the program, so that code 
+generation allocates the array as it would any other &ndash; see 
+`docs/system/basic-language.md`.
+
 
 ## Main Classes
 

--- a/docs/languages/basic.md
+++ b/docs/languages/basic.md
@@ -123,6 +123,29 @@ The table below lists the BASIC constructs implemented so far.
 Note that BASIC keywords are case-insensitive, but built-in function names must be
 written in lowercase.
 
+## Variable and array types
+
+A variable gets its type from the first of these that applies: the type specifier at
+the end of its name (`%` for integer, `$` for string, `#` for double), the `AS` clause
+of a `DIM` statement, a `DEFINT`/`DEFSTR`/`DEFDBL` statement covering its first letter,
+or the default type, which is `DOUBLE`. (QuickBASIC's default type is `SINGLE`, which
+JCC does not have.)
+
+The `AS` clause of a `DIM` statement is therefore optional, as in QuickBASIC:
+
+```BASIC
+DIM count%(10)          ' Array of integer
+DIM name$(10)           ' Array of string
+DEFINT i-n : DIM i(10)  ' Array of integer
+DIM value(10)           ' Array of double, the default type
+```
+
+An array that is used without having been declared is created implicitly, again as in
+QuickBASIC. It gets as many dimensions as its first use has subscripts, and the
+inclusive upper bound 10 in every dimension &ndash; so `total%(3) = 7` is equivalent to
+writing `DIM total%(10) AS INTEGER` first. Compile with `-Wundefined-variable` to be
+warned where this happens.
+
 ## Operator precedence
 
 When several operators appear in one expression, they are applied in the order

--- a/docs/system/basic-language.md
+++ b/docs/system/basic-language.md
@@ -19,6 +19,43 @@ QuickBASIC's `FOR ... NEXT` is not implemented — `Basic.g4` has no rule for it
 a `FOR` line fails to parse. Use `WHILE ... WEND` for counted loops (the idiom in
 every BASIC integration test).
 
+## Implicit arrays must reach the AST, not just a symbol table
+
+An array used without a `DIM` is defined implicitly (QuickBASIC does this), by
+`BasicSemanticsParser.defineImplicitArray`. Registering it in the semantics parser's
+symbol table is **not enough**: `CompilerFactory` hands the semantics parser and the
+code generator *separate* `SymbolTable` instances, and static arrays are emitted by
+`AbstractLlvmCodeGenerator.generateGlobals` from the code generator's table, which is
+populated from `VariableDeclarationStatement` nodes in the AST. So `parse` prepends a
+synthetic `VariableDeclarationStatement` holding every implicit declaration. Routing it
+through the normal declaration statement is also what makes the FASM backend work — it
+has its own `VariableDeclarationCodeGenerator` doing the same registration.
+
+Two consequences to keep in mind. The subscripts of a synthetic `ArrayDeclaration` must
+be **pre-adjusted** for BASIC's inclusive upper bound (upper bound 10 → subscript 11);
+`arrayDimensionSizes` evaluates them as sizes directly. And the array must be registered
+with `symbols.addGlobalArray`, not `addArray`, so that an array first used inside a
+`DEF FN` body — parsed under `withLocalSymbolTable` — still lands in the root scope.
+
+## `ident(args)` in an expression is not necessarily a function call
+
+The grammar has no `arrayElement` alternative in `factor`, so a read like `a(3)` parses
+as a `FunctionCallExpression`; only the assignment target uses `arrayElement`. That
+makes `BasicSemanticsParser.functionCall` the disambiguator, and its branch order is
+load-bearing:
+
+1. known array with matching numeric subscripts → array access
+2. known function → function call
+3. known array, wrong subscript count or non-numeric subscript → error
+4. one or more args, all numeric → implicitly defined array
+5. otherwise → `undefined function`
+
+Functions are checked *before* the array diagnostics (3) so that a name which is both an
+array and a function still resolves as a function. Branch 4 means a mistyped call with
+numeric arguments is no longer an error — `PRINT foo(17)` silently becomes an array, as
+in QuickBASIC. That is deliberate, and matches how a mistyped *scalar* has always been
+treated; `-Wundefined-variable` is what surfaces both.
+
 ## Operator precedence is one-level-per-rule
 
 The expression grammar is a layered cascade — `expr → impExpr → eqvExpr → xorExpr

--- a/docs/system/basic-language.md
+++ b/docs/system/basic-language.md
@@ -56,6 +56,28 @@ numeric arguments is no longer an error — `PRINT foo(17)` silently becomes an 
 in QuickBASIC. That is deliberate, and matches how a mistyped *scalar* has always been
 treated; `-Wundefined-variable` is what surfaces both.
 
+## One symbol table per test method, not per `parse()` call
+
+`AbstractBasicSemanticsParserTests` holds `symbolTable` as a field, and JUnit's default
+per-method lifecycle makes it fresh for each test method — but every `parse()` call
+*within* one method shares it. So a second `parse()` re-using a variable name fails with
+"variable 'a' is already defined", which reads like a parser bug and is not one. Give each
+`parse()` in a method distinct names (`dim a(10)`, `dim b%(10)`, `dim c$(10)`), as the
+existing tests do.
+
+## Array subscript mismatches must be reported before the node is rebuilt
+
+`ArrayAccessExpression`'s constructor (in `jcc-base`) asserts that the identifier type is
+an `Arr`, that the subscript list is non-empty, and that its size equals the array's
+dimension count. `withIdentifier` and `withSubscripts` re-run the constructor, so a
+semantics-parser branch that detects a subscript mismatch must `reportError` and return
+the *original* expression — building the updated node instead throws `AssertionError`
+in place of the diagnostic. `BasicSemanticsParser.arrayAccessExpression` does this.
+
+These are Java `assert`s: Surefire enables `-ea`, so the mismatch surfaces as a test
+failure, but a released compiler has assertions off and would carry the broken AST into
+code generation. Treat the assert as a test-only backstop, not the check itself.
+
 ## Operator precedence is one-level-per-rule
 
 The expression grammar is a layered cascade — `expr → impExpr → eqvExpr → xorExpr

--- a/docs/system/basic-language.md
+++ b/docs/system/basic-language.md
@@ -31,11 +31,26 @@ synthetic `VariableDeclarationStatement` holding every implicit declaration. Rou
 through the normal declaration statement is also what makes the FASM backend work — it
 has its own `VariableDeclarationCodeGenerator` doing the same registration.
 
-Two consequences to keep in mind. The subscripts of a synthetic `ArrayDeclaration` must
+Consequences to keep in mind. The subscripts of a synthetic `ArrayDeclaration` must
 be **pre-adjusted** for BASIC's inclusive upper bound (upper bound 10 → subscript 11);
-`arrayDimensionSizes` evaluates them as sizes directly. And the array must be registered
+`arrayDimensionSizes` evaluates them as sizes directly. The array must be registered
 with `symbols.addGlobalArray`, not `addArray`, so that an array first used inside a
 `DEF FN` body — parsed under `withLocalSymbolTable` — still lands in the root scope.
+And the `implicitArrays` list is cleared at the top of `parse`, because it feeds the
+*returned* AST: a parser instance reused for a second program (only tests do this) would
+otherwise prepend the first program's declarations to the second one's statements.
+
+The declaration is prepended at index 0, so it precedes any `OPTION BASE` — an order
+source code is not allowed to use. That is safe, and the reason is worth knowing before
+changing it: `optionBaseStatement` runs during the traversal of the *input* statements,
+so the synthetic declaration never reaches that check, and neither backend's
+`VariableDeclarationCodeGenerator` emits code for an array — each only registers it in
+the code generator's symbol table, with the storage itself emitted later from that table
+(`generateGlobals` on LLVM, the data section on FASM). So the base is still set before
+anything reads it, which `LBOUND`/`UBOUND` on an implicit array confirms. Array
+allocation that *did* depend on the base — QuickBASIC's `OPTION BASE 1` makes upper
+bound 10 mean 10 elements, not the 11 JCC always allocates — would break this, and the
+declaration would then have to be inserted after any leading `OPTION BASE` instead.
 
 ## `ident(args)` in an expression is not necessarily a function call
 
@@ -64,6 +79,14 @@ per-method lifecycle makes it fresh for each test method — but every `parse()`
 "variable 'a' is already defined", which reads like a parser bug and is not one. Give each
 `parse()` in a method distinct names (`dim a(10)`, `dim b%(10)`, `dim c$(10)`), as the
 existing tests do.
+
+## A `$` in a BASIC identifier needs no escaping in a Kotlin test string
+
+Kotlin only starts a string template when `$` is followed by an identifier character or
+`{`, so `"dim a$(3) as string"` and `"print s$"` are plain strings — no `\$`, and no `$$`
+multi-dollar prefix. Write them unescaped, as the array tests do. The escape is needed
+only when the `$` really does begin an identifier, as in the expected message
+`$$"$DYNAMIC arrays not supported yet"`.
 
 ## Array subscript mismatches must be reported before the node is rebuilt
 

--- a/jcc-basic/src/main/antlr4/se/dykstrom/jcc/basic/compiler/Basic.g4
+++ b/jcc-basic/src/main/antlr4/se/dykstrom/jcc/basic/compiler/Basic.g4
@@ -98,7 +98,6 @@ defFnStmt
    ;
 
 paramDecl
-   /* Unlike in varDecl, the type is optional here. */
    : ident (AS (TYPE_DOUBLE | TYPE_INTEGER | TYPE_STRING))?
    ;
 
@@ -123,8 +122,8 @@ dimStmt
    ;
 
 varDecl
-   : ident AS (TYPE_DOUBLE | TYPE_INTEGER | TYPE_STRING)
-   | ident OPEN subscriptDecl (COMMA subscriptDecl)* CLOSE AS (TYPE_DOUBLE | TYPE_INTEGER | TYPE_STRING)
+   /* Without an AS clause, the type comes from the type specifier, DEFtype, or the default type. */
+   : ident (OPEN subscriptDecl (COMMA subscriptDecl)* CLOSE)? (AS (TYPE_DOUBLE | TYPE_INTEGER | TYPE_STRING))?
    ;
 
 subscriptDecl

--- a/jcc-basic/src/main/java/se/dykstrom/jcc/basic/compiler/BasicSemanticsParser.java
+++ b/jcc-basic/src/main/java/se/dykstrom/jcc/basic/compiler/BasicSemanticsParser.java
@@ -180,13 +180,18 @@ public class BasicSemanticsParser extends AbstractSemanticsParser<BasicTypeManag
 
     @Override
     public AstProgram parse(final AstProgram program) throws SemanticsException {
+        // Only arrays defined by this call may be declared in the program it returns
+        implicitArrays.clear();
         program.getStatements().forEach(this::lineNumber);
         final var statements = new ArrayList<Statement>(program.getStatements().stream().map(this::statement).toList());
         usageTracker.check((n, m) -> reportWarning(n, m, UNUSED_VARIABLE));
         if (errorListener.hasErrors()) {
             throw new SemanticsException("Semantics error");
         }
-        // Declare implicitly defined arrays up front, so that code generation allocates them
+        // Declare implicitly defined arrays up front, so that code generation allocates them.
+        // This puts the declaration before any OPTION BASE, which source code may not do, but
+        // neither backend emits code for an array declaration - it only registers the array in
+        // the code generator's symbol table - so the base is still set before anything reads it.
         if (!implicitArrays.isEmpty()) {
             statements.addFirst(new VariableDeclarationStatement(0, 0, List.copyOf(implicitArrays), GLOBAL));
         }

--- a/jcc-basic/src/main/java/se/dykstrom/jcc/basic/compiler/BasicSemanticsParser.java
+++ b/jcc-basic/src/main/java/se/dykstrom/jcc/basic/compiler/BasicSemanticsParser.java
@@ -91,6 +91,7 @@ import se.dykstrom.jcc.common.types.Type;
 import se.dykstrom.jcc.common.utils.ExpressionUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -103,6 +104,7 @@ import static se.dykstrom.jcc.basic.type.BasicTypeHelper.updateTypes;
 import static se.dykstrom.jcc.common.error.Warning.FLOAT_CONVERSION;
 import static se.dykstrom.jcc.common.error.Warning.UNDEFINED_VARIABLE;
 import static se.dykstrom.jcc.common.error.Warning.UNUSED_VARIABLE;
+import static se.dykstrom.jcc.common.symbols.Scope.GLOBAL;
 import static se.dykstrom.jcc.common.utils.ExpressionUtils.evaluateExpression;
 import static se.dykstrom.jcc.llvm.code.LlvmBuiltIns.LF_ROUNDEVEN_F64;
 
@@ -117,13 +119,24 @@ import static se.dykstrom.jcc.llvm.code.LlvmBuiltIns.LF_ROUNDEVEN_F64;
  * - If the identifier has been declared in a DIM statement, like "DIM a AS STRING", this decides the type.
  * - If the identifier starts with a letter used in a DEFtype statement, like "DEFSTR a-c", this decides the type.
  * - If neither of the above applies, the default type is used, and that is Double.
+ * <p>
+ * An array that is used without having been declared in a DIM statement is defined implicitly,
+ * as in QuickBASIC: it gets the element type decided by the rules above, as many dimensions as
+ * the first use has subscripts, and the inclusive upper bound
+ * {@value #IMPLICIT_ARRAY_UPPER_BOUND} in every dimension.
  *
  * @author Johan Dykstrom
  */
 public class BasicSemanticsParser extends AbstractSemanticsParser<BasicTypeManager> {
 
+    /** Inclusive upper bound given to each dimension of an implicitly defined array, as in QuickBASIC. */
+    private static final long IMPLICIT_ARRAY_UPPER_BOUND = 10;
+
     /** A set of all line numbers used in the program (for undefined/duplicate line number warnings). */
     private final Set<String> lineNumbers = new HashSet<>();
+
+    /** Arrays implicitly defined by their first use, to be declared at the start of the program. */
+    private final List<Declaration> implicitArrays = new ArrayList<>();
 
     /** Tracks variable declaration and usage for unused variable warnings. */
     private final VariableUsageTracker usageTracker = new VariableUsageTracker();
@@ -168,10 +181,14 @@ public class BasicSemanticsParser extends AbstractSemanticsParser<BasicTypeManag
     @Override
     public AstProgram parse(final AstProgram program) throws SemanticsException {
         program.getStatements().forEach(this::lineNumber);
-        List<Statement> statements = program.getStatements().stream().map(this::statement).toList();
+        final var statements = new ArrayList<Statement>(program.getStatements().stream().map(this::statement).toList());
         usageTracker.check((n, m) -> reportWarning(n, m, UNUSED_VARIABLE));
         if (errorListener.hasErrors()) {
             throw new SemanticsException("Semantics error");
+        }
+        // Declare implicitly defined arrays up front, so that code generation allocates them
+        if (!implicitArrays.isEmpty()) {
+            statements.addFirst(new VariableDeclarationStatement(0, 0, List.copyOf(implicitArrays), GLOBAL));
         }
         return program.withStatements(statements);
     }
@@ -655,7 +672,8 @@ public class BasicSemanticsParser extends AbstractSemanticsParser<BasicTypeManag
 
     /**
      * Parses a function call expression. An FCE may also turn out be an array access expression,
-     * in which case this method will instead return an array access expression.
+     * in which case this method will instead return an array access expression. The array may be
+     * undefined, in which case it is defined implicitly, as in QuickBASIC.
      */
 	private Expression functionCall(FunctionCallExpression fce) {
         // Check and update arguments
@@ -709,14 +727,69 @@ public class BasicSemanticsParser extends AbstractSemanticsParser<BasicTypeManag
             } catch (SemanticsException e) {
                 reportError(fce.line(), fce.column(), e.getMessage(), e);
             }
+        } else if (symbols.containsArray(name)) {
+            // The identifier is an array, but the arguments are not valid subscripts.
+            // Note that this case is checked after functions, so that an identifier that
+            // is both an array and a function is still resolved as a function.
+            reportInvalidArraySubscripts(fce, name, argTypes, symbols.getArrayType(name).getDimensions());
+        } else if (argsAreValidArraySubscripts(argTypes)) {
+            // The identifier is an undefined array, so define it implicitly (QuickBASIC allows this)
+            final var arrayType = Arr.from(args.size(), ((Fun) identifier.type()).getReturnType());
+            defineImplicitArray(fce, name, arrayType);
+            // Evaluate as array access expression with original arguments
+            return expression(new ArrayAccessExpression(fce.line(), fce.column(), identifier.withType(arrayType), fce.getArgs()));
         } else {
-            // Note that this can also be an array access expression with
-            // an undefined array (which is allowed in QuickBASIC)
             String msg = "undefined function: " + name;
             reportError(fce.line(), fce.column(), msg, new UndefinedException(msg, name));
         }
 
 	    return fce;
+    }
+
+    /**
+     * Reports why {@code argTypes} are not valid subscripts in an access of the array {@code name},
+     * which has {@code dimensions} dimensions.
+     */
+    private void reportInvalidArraySubscripts(final Expression expression,
+                                              final String name,
+                                              final List<Type> argTypes,
+                                              final int dimensions) {
+        final String msg;
+        if (argTypes.stream().allMatch(NumericType.class::isInstance)) {
+            msg = "array '" + name + "' has " + dimensions + " dimension" + (dimensions == 1 ? "" : "s")
+                    + ", not " + argTypes.size();
+        } else {
+            msg = "array '" + name + "' has non-integer subscript";
+        }
+        reportError(expression.line(), expression.column(), msg, new InvalidTypeException(msg, Arr.INSTANCE));
+    }
+
+    /**
+     * Returns {@code true} if the given types can be subscripts in an array access, that is,
+     * if there is at least one of them and they are all numeric.
+     */
+    private boolean argsAreValidArraySubscripts(final List<Type> argTypes) {
+        return !argTypes.isEmpty() && argTypes.stream().allMatch(NumericType.class::isInstance);
+    }
+
+    /**
+     * Defines the array {@code name} of type {@code arrayType} implicitly, as QuickBASIC does for
+     * arrays that are used without having been declared. Every dimension gets the inclusive upper
+     * bound {@value #IMPLICIT_ARRAY_UPPER_BOUND}, making the array equivalent to one declared with
+     * a DIM statement. The declaration is remembered, and added to the program by {@link #parse}.
+     */
+    private void defineImplicitArray(final Expression expression, final String name, final Arr arrayType) {
+        reportWarning(expression, "undefined array: " + name, UNDEFINED_VARIABLE);
+
+        // The upper bound of an array declaration is inclusive, so the size is one more than that,
+        // just like for the subscripts of an explicit array declaration
+        final Expression size = new IntegerLiteral(expression.line(), expression.column(), IMPLICIT_ARRAY_UPPER_BOUND + 1);
+        final var subscripts = Collections.nCopies(arrayType.getDimensions(), size);
+        final var declaration = new ArrayDeclaration(expression.line(), expression.column(), name, arrayType, subscripts);
+
+        // Arrays are global in Basic, also when first used inside a user-defined function
+        symbols.addGlobalArray(new Identifier(name, arrayType), declaration);
+        implicitArrays.add(declaration);
     }
 
     /**
@@ -762,8 +835,21 @@ public class BasicSemanticsParser extends AbstractSemanticsParser<BasicTypeManag
             usageTracker.use(name);
             // If the identifier is present in the symbol table, reuse that one
             identifier = symbols.getArrayIdentifier(name);
+        } else {
+            // The array is undefined, so define it implicitly (QuickBASIC allows this)
+            defineImplicitArray(expression, name, (Arr) identifier.type());
         }
         final List<Expression> subscripts = expression.getSubscripts().stream().map(this::expression).toList();
+
+        // Check that the subscripts are numeric, and that there are as many of them as the
+        // array has dimensions. Return the original expression if not, since the updated
+        // expression below requires the number of subscripts to match the number of dimensions.
+        final var subscriptTypes = types.getTypes(subscripts);
+        final int dimensions = ((Arr) identifier.type()).getDimensions();
+        if (subscripts.size() != dimensions || !argsAreValidArraySubscripts(subscriptTypes)) {
+            reportInvalidArraySubscripts(expression, name, subscriptTypes, dimensions);
+            return expression;
+        }
 
         // For each subscript, warn about an implicit float-to-int conversion, and make it explicit (issue #52)
         final List<Expression> castSubscripts = subscripts.stream().map(subscript -> {

--- a/jcc-basic/src/main/java/se/dykstrom/jcc/basic/compiler/BasicSyntaxVisitor.java
+++ b/jcc-basic/src/main/java/se/dykstrom/jcc/basic/compiler/BasicSyntaxVisitor.java
@@ -258,7 +258,8 @@ public class BasicSyntaxVisitor extends BasicBaseVisitor<Node> {
 
     @Override
     public Node visitVarDecl(VarDeclContext ctx) {
-        Type type;
+        final var identifier = ((IdentifierExpression) ctx.ident().accept(this)).getIdentifier();
+        final Type type;
         if (isValid(ctx.TYPE_DOUBLE())) {
             type = F64.INSTANCE;
         } else if (isValid(ctx.TYPE_INTEGER())) {
@@ -266,12 +267,13 @@ public class BasicSyntaxVisitor extends BasicBaseVisitor<Node> {
         } else if (isValid(ctx.TYPE_STRING())) {
             type = Str.INSTANCE;
         } else {
-            throw new IllegalArgumentException("unknown type: " + ctx.getText());
+            // Without an AS clause, the identifier itself decides the type
+            type = identifier.type();
         }
 
         int line = ctx.getStart().getLine();
         int column = ctx.getStart().getCharPositionInLine();
-        String name = ctx.ident().getText();
+        String name = identifier.name();
 
         // If this is an array declaration, find out its dimensions and subscripts
         if (!ctx.subscriptDecl().isEmpty()) {

--- a/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/BasicTests.kt
+++ b/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/BasicTests.kt
@@ -57,6 +57,7 @@ class BasicTests {
         val IL_4 = IntegerLiteral(0, 0, "4")
         val IL_5 = IntegerLiteral(0, 0, "5")
         val IL_10 = IntegerLiteral(0, 0, "10")
+        val IL_11 = IntegerLiteral(0, 0, "11")
         val IL_53 = IntegerLiteral(0, 0, "53")
         val IL_255 = IntegerLiteral(0, 0, "255")
         val IL_M1 = IntegerLiteral(0, 0, "-1")

--- a/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicParserArrayTests.kt
+++ b/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicParserArrayTests.kt
@@ -35,9 +35,10 @@ class BasicParserArrayTests : AbstractBasicParserTests() {
     }
 
     @Test
-    fun shouldRejectMissingType() {
-        // This is allowed in QuickBasic, but not implemented here yet
-        assertThrows<IllegalStateException> { parse("dim a(6)") }
+    fun shouldParseDimStatementWithoutType() {
+        parse("dim a(6)")
+        parse("dim a%(6), b$(1, 2), c#(3)")
+        parse("dim q, w(1) as integer, e#")
     }
 
     @Test

--- a/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicSemanticsParserArrayTests.kt
+++ b/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicSemanticsParserArrayTests.kt
@@ -25,6 +25,7 @@ import se.dykstrom.jcc.basic.BasicTests.Companion.FL_3_14
 import se.dykstrom.jcc.basic.BasicTests.Companion.IL_0
 import se.dykstrom.jcc.basic.BasicTests.Companion.IL_1
 import se.dykstrom.jcc.basic.BasicTests.Companion.IL_2
+import se.dykstrom.jcc.basic.BasicTests.Companion.IL_11
 import se.dykstrom.jcc.basic.ast.statement.OptionBaseStatement
 import se.dykstrom.jcc.basic.ast.statement.PrintStatement
 import se.dykstrom.jcc.basic.compiler.BasicSymbols.BF_CINT_F64
@@ -88,9 +89,11 @@ class BasicSemanticsParserArrayTests : AbstractBasicSemanticsParserTests() {
 
     @Test
     fun shouldParseScalarDimWithoutType() {
-        val declarations = (parse("dim a, b%, c$, d#") as AstProgram).statements[0]
-            .let { (it as VariableDeclarationStatement).declarations }
-        assertEquals(listOf(F64.INSTANCE, I64.INSTANCE, Str.INSTANCE, F64.INSTANCE), declarations.map { it.type() })
+        val program = parse("dim a, b%, c$, d#")
+
+        val statement = program.statements[0] as VariableDeclarationStatement
+        val types = statement.declarations.map { it.type() }
+        assertEquals(listOf(F64.INSTANCE, I64.INSTANCE, Str.INSTANCE, F64.INSTANCE), types)
     }
 
     /**
@@ -143,6 +146,31 @@ class BasicSemanticsParserArrayTests : AbstractBasicSemanticsParserTests() {
         val dimStatement = program.statements[0] as VariableDeclarationStatement
         assertEquals(1, dimStatement.declarations.size)
         assertEquals(1, errorListener.warnings.size)
+    }
+
+    /**
+     * The implicit declarations of one program must not leak into the next one parsed by
+     * the same parser instance.
+     */
+    @Test
+    fun shouldNotDeclareImplicitArrayOfEarlierProgram() {
+        parse("a(3) = 7")
+
+        val program = parse("print 1")
+
+        assertEquals(listOf(PrintStatement(0, 0, listOf(IL_1))), program.statements)
+    }
+
+    /**
+     * The implicit declaration is added before any OPTION BASE, which source code may not do,
+     * but only the semantics parser enforces that order, and it has already run.
+     */
+    @Test
+    fun shouldAllowOptionBaseBeforeImplicitArray() {
+        val program = parse("option base 1 : a(3) = 7")
+
+        assertEquals(Arr.from(1, F64.INSTANCE), arrayDeclaration(program).type())
+        assertEquals(OptionBaseStatement(0, 0, 1), program.statements[1])
     }
 
     @Test
@@ -436,7 +464,25 @@ class BasicSemanticsParserArrayTests : AbstractBasicSemanticsParserTests() {
         parseAndExpectException("dim a(1) as integer : print a(\"0\")", "array 'a' has non-integer subscript")
         parseAndExpectException("dim b(1, 2) as integer : print b(\"5\")", "array 'b' has non-integer subscript")
         parseAndExpectException("dim a(1) as integer : a(\"0\") = 1", "array 'a' has non-integer subscript")
-        parseAndExpectException($$"b$(\"0\") = \"x\"", "array 'b$' has non-integer subscript")
+        parseAndExpectException("b$(\"0\") = \"x\"", "array 'b$' has non-integer subscript")
+    }
+
+    /**
+     * A floating point subscript is legal, on both sides of an assignment. It is rounded
+     * (half-to-even) to an integer, as in QuickBASIC.
+     *
+     * @see shouldParseArrayAccessWithFloatSubscripts
+     */
+    @Test
+    fun shouldRoundFloatSubscriptInAssignmentTarget() {
+        val program = parse("dim a%(10) as integer : a%(1.7) = 5")
+
+        val assignStatement = program.statements[1] as AssignStatement
+        val arrayAccessExpression = assignStatement.lhsExpression as ArrayAccessExpression
+        assertEquals(
+            CastToI64Expression(0, 0, RoundExpression(FloatLiteral(0, 0, "1.7"), LF_ROUNDEVEN_F64)),
+            arrayAccessExpression.subscripts[0]
+        )
     }
 
     /**
@@ -453,9 +499,4 @@ class BasicSemanticsParserArrayTests : AbstractBasicSemanticsParserTests() {
      */
     private fun arrayDeclaration(program: AstProgram, index: Int = 0): ArrayDeclaration =
         (program.statements[index] as VariableDeclarationStatement).declarations[0] as ArrayDeclaration
-
-    companion object {
-        /** The size of every dimension of an implicitly defined array: the upper bound 10, plus one. */
-        private val IL_11 = IntegerLiteral(0, 0, 11)
-    }
 }

--- a/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicSemanticsParserArrayTests.kt
+++ b/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicSemanticsParserArrayTests.kt
@@ -30,6 +30,8 @@ import se.dykstrom.jcc.basic.ast.statement.PrintStatement
 import se.dykstrom.jcc.basic.compiler.BasicSymbols.BF_CINT_F64
 import se.dykstrom.jcc.basic.compiler.BasicSymbols.BF_VAL_STR
 import se.dykstrom.jcc.common.ast.*
+import se.dykstrom.jcc.common.error.Warning.UNDEFINED_VARIABLE
+import se.dykstrom.jcc.common.error.Warning.UNUSED_VARIABLE
 import se.dykstrom.jcc.llvm.code.LlvmBuiltIns.LF_ROUNDEVEN_F64
 import se.dykstrom.jcc.common.types.Arr
 import se.dykstrom.jcc.common.types.F64
@@ -63,6 +65,100 @@ class BasicSemanticsParserArrayTests : AbstractBasicSemanticsParserTests() {
         parse("dim a%(10) as integer")
         parse("dim bar$(999) as string")
         parse("dim foo#(99) as double")
+    }
+
+    /**
+     * Without an AS clause, the element type comes from the type specifier, from a DEFtype
+     * statement, or from the default type, which is double.
+     */
+    @Test
+    fun shouldParseDimWithoutType() {
+        assertEquals(Arr.from(1, F64.INSTANCE), arrayDeclaration(parse("dim a(10)")).type())
+        assertEquals(Arr.from(1, I64.INSTANCE), arrayDeclaration(parse("dim b%(10)")).type())
+        assertEquals(Arr.from(1, Str.INSTANCE), arrayDeclaration(parse("dim c$(10)")).type())
+        assertEquals(Arr.from(1, F64.INSTANCE), arrayDeclaration(parse("dim d#(10)")).type())
+        assertEquals(Arr.from(2, F64.INSTANCE), arrayDeclaration(parse("dim e(1, 2)")).type())
+    }
+
+    @Test
+    fun shouldParseDimWithoutTypeAfterDefType() {
+        assertEquals(Arr.from(1, I64.INSTANCE), arrayDeclaration(parse("defint b-c : dim b(5)"), 1).type())
+        assertEquals(Arr.from(1, Str.INSTANCE), arrayDeclaration(parse("defstr s : dim s(5)"), 1).type())
+    }
+
+    @Test
+    fun shouldParseScalarDimWithoutType() {
+        val declarations = (parse("dim a, b%, c$, d#") as AstProgram).statements[0]
+            .let { (it as VariableDeclarationStatement).declarations }
+        assertEquals(listOf(F64.INSTANCE, I64.INSTANCE, Str.INSTANCE, F64.INSTANCE), declarations.map { it.type() })
+    }
+
+    /**
+     * An array that is used without having been declared is defined implicitly, with the
+     * inclusive upper bound 10 in every dimension. The declaration is added to the start
+     * of the program, so that the array is allocated before it is used.
+     */
+    @Test
+    fun shouldDefineUndefinedArrayImplicitly() {
+        val program = parse("a(3) = 7")
+
+        val declaration = arrayDeclaration(program)
+        assertEquals("a", declaration.name())
+        assertEquals(Arr.from(1, F64.INSTANCE), declaration.type())
+        assertEquals(listOf(IL_11), declaration.subscripts)
+    }
+
+    @Test
+    fun shouldDefineUndefinedArrayImplicitlyWhenRead() {
+        val program = parse("print a(3)")
+
+        val declaration = arrayDeclaration(program)
+        assertEquals("a", declaration.name())
+        assertEquals(Arr.from(1, F64.INSTANCE), declaration.type())
+        assertEquals(listOf(IL_11), declaration.subscripts)
+
+        val printStatement = program.statements[1] as PrintStatement
+        val arrayAccessExpression = printStatement.expressions[0] as ArrayAccessExpression
+        assertEquals(F64.INSTANCE, arrayAccessExpression.type())
+    }
+
+    @Test
+    fun shouldDefineUndefinedMultiDimensionalArrayImplicitly() {
+        val declaration = arrayDeclaration(parse("b%(2, 3) = 5"))
+        assertEquals("b%", declaration.name())
+        assertEquals(Arr.from(2, I64.INSTANCE), declaration.type())
+        assertEquals(listOf(IL_11, IL_11), declaration.subscripts)
+    }
+
+    @Test
+    fun shouldDefineUndefinedArrayImplicitlyWithTypeFromDefType() {
+        val declaration = arrayDeclaration(parse("defint a-c : a(3) = 7"), 0)
+        assertEquals(Arr.from(1, I64.INSTANCE), declaration.type())
+    }
+
+    @Test
+    fun shouldDefineImplicitArrayOnlyOnce() {
+        val program = parse("a(3) = 7 : print a(4) : a(5) = a(3)")
+
+        val dimStatement = program.statements[0] as VariableDeclarationStatement
+        assertEquals(1, dimStatement.declarations.size)
+        assertEquals(1, errorListener.warnings.size)
+    }
+
+    @Test
+    fun shouldWarnAboutUndefinedArray() {
+        parseAndExpectWarning("a(3) = 7", "undefined array: a", UNDEFINED_VARIABLE)
+        assertEquals(1, errorListener.warnings.size)
+    }
+
+    /**
+     * An implicitly defined array is never reported as unused, just like an implicitly
+     * defined scalar variable.
+     */
+    @Test
+    fun shouldNotWarnAboutUnusedImplicitArray() {
+        parseAndExpectWarning("a(3) = 7", "undefined array: a", UNDEFINED_VARIABLE)
+        assertTrue(errorListener.warnings.none { it.warning == UNUSED_VARIABLE })
     }
 
     @Test
@@ -329,14 +425,18 @@ class BasicSemanticsParserArrayTests : AbstractBasicSemanticsParserTests() {
 
     @Test
     fun arrayAccessMustHaveSameDimensionsAsArrayDefinition() {
-        parseAndExpectException("dim a(1) as integer : print a(1, 7)", "undefined function: a")
-        parseAndExpectException("dim b(1, 2) as integer : print b(8)", "undefined function: b")
+        parseAndExpectException("dim a(1) as integer : print a(1, 7)", "array 'a' has 1 dimension, not 2")
+        parseAndExpectException("dim b(1, 2) as integer : print b(8)", "array 'b' has 2 dimensions, not 1")
+        parseAndExpectException("dim a(1) as integer : a(1, 7) = 0", "array 'a' has 1 dimension, not 2")
+        parseAndExpectException("dim b(1, 2) as integer : b(8) = 0", "array 'b' has 2 dimensions, not 1")
     }
 
     @Test
     fun arrayAccessMustUseNumericSubscripts() {
-        parseAndExpectException("dim a(1) as integer : print a(\"0\")", "undefined function: a")
-        parseAndExpectException("dim b(1, 2) as integer : print b(\"5\")", "undefined function: b")
+        parseAndExpectException("dim a(1) as integer : print a(\"0\")", "array 'a' has non-integer subscript")
+        parseAndExpectException("dim b(1, 2) as integer : print b(\"5\")", "array 'b' has non-integer subscript")
+        parseAndExpectException("dim a(1) as integer : a(\"0\") = 1", "array 'a' has non-integer subscript")
+        parseAndExpectException($$"b$(\"0\") = \"x\"", "array 'b$' has non-integer subscript")
     }
 
     /**
@@ -346,5 +446,16 @@ class BasicSemanticsParserArrayTests : AbstractBasicSemanticsParserTests() {
     fun shouldNotAcceptDynamicArrays() {
         parseAndExpectException("dim a as integer : dim foo(a) as integer", $$"$DYNAMIC arrays not supported yet")
         parseAndExpectException("dim b as integer : dim foo(7, 1 + b) as integer", $$"$DYNAMIC arrays not supported yet")
+    }
+
+    /**
+     * Returns the first array declaration of the variable declaration statement at [index].
+     */
+    private fun arrayDeclaration(program: AstProgram, index: Int = 0): ArrayDeclaration =
+        (program.statements[index] as VariableDeclarationStatement).declarations[0] as ArrayDeclaration
+
+    companion object {
+        /** The size of every dimension of an implicitly defined array: the upper bound 10, plus one. */
+        private val IL_11 = IntegerLiteral(0, 0, 11)
     }
 }

--- a/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicSemanticsParserFunctionTests.kt
+++ b/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicSemanticsParserFunctionTests.kt
@@ -252,7 +252,8 @@ class BasicSemanticsParserFunctionTests : AbstractBasicSemanticsParserTests() {
 
     @Test
     fun shouldNotParseCallToUndefined() {
-        parseAndExpectException("print foo(1, 2, 3)", "undefined function")
+        // With only numeric arguments this would be an implicitly defined array instead
+        parseAndExpectException("print foo(\"1\", 2, 3)", "undefined function")
     }
 
     @Test

--- a/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicSyntaxVisitorArrayTests.kt
+++ b/jcc-basic/src/test/kotlin/se/dykstrom/jcc/basic/compiler/BasicSyntaxVisitorArrayTests.kt
@@ -52,6 +52,19 @@ class BasicSyntaxVisitorArrayTests : AbstractBasicSyntaxVisitorTests() {
         parseAndAssert("dim arr(5) as integer", listOf(vds))
     }
 
+    /**
+     * Without an AS clause, the element type comes from the type specifier, from a DEFtype
+     * statement, or from the default type, which is double.
+     */
+    @Test
+    fun shouldParseArrayDeclarationWithoutType() {
+        val declaration = ArrayDeclaration(0, 0, "arr", Arr.from(1, F64.INSTANCE), listOf(IL_5))
+        parseAndAssert("dim arr(5)", listOf(VariableDeclarationStatement(listOf(declaration), Scope.GLOBAL)))
+
+        val declaration2 = ArrayDeclaration(0, 0, "arr%", Arr.from(2, I64.INSTANCE), listOf(IL_5, IL_3))
+        parseAndAssert("dim arr%(5, 3)", listOf(VariableDeclarationStatement(listOf(declaration2), Scope.GLOBAL)))
+    }
+
     @Test
     fun shouldParseMultiDimensionArrayDeclaration() {
         val declaration = ArrayDeclaration(0, 0, "arr", Arr.from(2, F64.INSTANCE), listOf(IDE_I64_A, IDE_I64_B))

--- a/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/BasicLlvmCompileAndRunArrayIT.kt
+++ b/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/BasicLlvmCompileAndRunArrayIT.kt
@@ -51,9 +51,9 @@ class BasicLlvmCompileAndRunArrayIT : AbstractIntegrationTests() {
                 "dim b$(10)",
                 "dim c(10)",
                 "a%(0) = 17",
-                "b\$(0) = \"foo\"",
+                "b$(0) = \"foo\"",
                 "c(0) = 1.5",
-                "print a%(0) ; \" \" ; b\$(0) ; \" \" ; c(0)"
+                "print a%(0) ; \" \" ; b$(0) ; \" \" ; c(0)"
             ),
             listOf("17 foo 1.500000")
         )
@@ -134,10 +134,44 @@ class BasicLlvmCompileAndRunArrayIT : AbstractIntegrationTests() {
             BASIC,
             listOf(
                 "a(3) = 1.5",
-                "b\$(3) = \"foo\"",
-                "print a(3) ; \" \" ; b\$(3)"
+                "b$(3) = \"foo\"",
+                "print a(3) ; \" \" ; b$(3)"
             ),
             listOf("1.500000 foo")
+        )
+    }
+
+    /**
+     * The implicit declaration is added to the start of the program, before any OPTION BASE,
+     * so verify that the base still applies to the implicitly defined array.
+     */
+    @Test
+    fun shouldDefineUndefinedArrayImplicitlyWithOptionBase1() {
+        compileAndRunLlvm(
+            BASIC,
+            listOf(
+                "option base 1",
+                "a%(3) = 7",
+                "print a%(3) ; \" \" ; lbound(a%) ; \" \" ; ubound(a%)"
+            ),
+            listOf("7 1 10")
+        )
+    }
+
+    /**
+     * A floating point subscript is rounded (half-to-even) to an integer, on both sides
+     * of an assignment.
+     */
+    @Test
+    fun shouldRoundFloatSubscript() {
+        compileAndRunLlvm(
+            BASIC,
+            listOf(
+                "dim a%(10) as integer",
+                "a%(1.7) = 7",
+                "print a%(2) ; \" \" ; a%(2.4)"
+            ),
+            listOf("7 7")
         )
     }
 

--- a/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/BasicLlvmCompileAndRunArrayIT.kt
+++ b/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/BasicLlvmCompileAndRunArrayIT.kt
@@ -43,6 +43,105 @@ class BasicLlvmCompileAndRunArrayIT : AbstractIntegrationTests() {
     }
 
     @Test
+    fun shouldDefineArrayWithoutType() {
+        compileAndRunLlvm(
+            BASIC,
+            listOf(
+                "dim a%(10)",
+                "dim b$(10)",
+                "dim c(10)",
+                "a%(0) = 17",
+                "b\$(0) = \"foo\"",
+                "c(0) = 1.5",
+                "print a%(0) ; \" \" ; b\$(0) ; \" \" ; c(0)"
+            ),
+            listOf("17 foo 1.500000")
+        )
+    }
+
+    @Test
+    fun shouldDefineArrayWithoutTypeAfterDefInt() {
+        compileAndRunLlvm(
+            BASIC,
+            listOf(
+                "defint a-c",
+                "dim b(10)",
+                "b(3) = 7 \\ 2",
+                "print b(3)"
+            ),
+            listOf("3")
+        )
+    }
+
+    /**
+     * An undefined array is defined implicitly, with the inclusive upper bound 10
+     * in every dimension, just like in QuickBASIC.
+     */
+    @Test
+    fun shouldDefineUndefinedArrayImplicitly() {
+        compileAndRunLlvm(
+            BASIC,
+            listOf(
+                "a%(3) = 7",
+                "print a%(3)"
+            ),
+            listOf("7")
+        )
+    }
+
+    @Test
+    fun shouldReadUndefinedArrayBeforeWriting() {
+        compileAndRunLlvm(
+            BASIC,
+            listOf("print a%(3)"),
+            listOf("0")
+        )
+    }
+
+    @Test
+    fun shouldUseAllElementsOfImplicitArray() {
+        compileAndRunLlvm(
+            BASIC,
+            listOf(
+                "a%(0) = 1",
+                "a%(10) = 2",
+                "print a%(0) + a%(10)"
+            ),
+            listOf("3")
+        )
+    }
+
+    @Test
+    fun shouldDefineUndefinedMultiDimensionalArrayImplicitly() {
+        compileAndRunLlvm(
+            BASIC,
+            listOf(
+                "b%(2, 3) = 5",
+                "b%(10, 10) = 6",
+                "print b%(2, 3) ; \" \" ; b%(10, 10)"
+            ),
+            listOf("5 6")
+        )
+    }
+
+    /**
+     * An implicitly defined array gets its element type from the type specifier,
+     * from a DEFtype statement, or from the default type, which is double.
+     */
+    @Test
+    fun shouldDefineUndefinedArrayWithDefaultType() {
+        compileAndRunLlvm(
+            BASIC,
+            listOf(
+                "a(3) = 1.5",
+                "b\$(3) = \"foo\"",
+                "print a(3) ; \" \" ; b\$(3)"
+            ),
+            listOf("1.500000 foo")
+        )
+    }
+
+    @Test
     fun shouldDefineArrayUsingConstant() {
         compileAndRunLlvm(
             BASIC,

--- a/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/JccTests.kt
+++ b/jcc-compiler/src/test/kotlin/se/dykstrom/jcc/main/JccTests.kt
@@ -131,7 +131,8 @@ class JccTests {
     @Test
     fun shouldReportUndefinedFunctionError() {
         // Given
-        val (sourcePath, _) = createSourceFile("PRINT foo(17)")
+        // With only numeric arguments this would be an implicitly defined array instead
+        val (sourcePath, _) = createSourceFile("PRINT foo(\"17\")")
         val args = arrayOf("-S", sourcePath.toString())
 
         // When
@@ -141,6 +142,21 @@ class JccTests {
 
         // Then
         assertTrue(output.contains("error: undefined function: foo"))
+    }
+
+    @Test
+    fun shouldReportUndefinedArrayWarning() {
+        // Given
+        val (sourcePath, _) = createSourceFile("a(3) = 7")
+        val args = arrayOf("-S", "-Wundefined-variable", sourcePath.toString())
+
+        // When
+        val output = tapSystemErr {
+            assertEquals(0, Jcc(args).run())
+        }
+
+        // Then
+        assertTrue(output.contains("warning: undefined array: a"))
     }
 
     @Test


### PR DESCRIPTION
## What is this

JCC's BASIC required an `AS type` clause on every `DIM`, and had no way to use an
array that was never declared. QuickBASIC 4.5 allows both. Using an undeclared array
as an assignment target also crashed the compiler with a Java stack trace
(`IllegalArgumentException: undefined array: a` out of `SymbolTable.findArrayByName`).

## Approach

- **Type without `AS`:** taken from the type specifier, then `DEFtype`, then the
  default type — which is `DOUBLE`, since JCC has no `SINGLE`.
- **Implicit arrays reach the AST:** `parse` prepends a synthetic declaration
  statement. Registering them in the semantics parser's symbol table is not enough —
  it and the code generator get separate `SymbolTable` instances.
- **The pending declarations are cleared per `parse` call:** they feed the returned
  AST, so a reused parser would leak them into the next program.
- **Upper bound 10 per dimension:** exactly as QuickBASIC, so `a(3) = 7` is
  equivalent to writing `DIM a(10)` first.
- **Functions resolve before the new array diagnostics:** a name that is both an
  array and a function still calls the function.
- **Subscript diagnostics replace a misleading error:** a wrongly-subscripted known
  array reported `undefined function: a`; it now says what is actually wrong.

## Risks / follow-ups

- **A mistyped call with numeric arguments is no longer an error:** `PRINT foo(17)`
  becomes an implicit array. This is QuickBASIC's behaviour and matches how a
  mistyped scalar has always been treated; `-Wundefined-variable` surfaces both.
- **The synthetic declaration is prepended ahead of any `OPTION BASE`:** an order
  source code may not use. Harmless today — the semantics check runs over the input
  statements, and an array declaration emits no code, only a symbol-table entry — and
  now covered by a test on both layers. It stops being harmless if array *allocation*
  ever depends on the base, which it arguably should: QuickBASIC's
  `OPTION BASE 1 : DIM a(10)` is 10 elements, where JCC always allocates 11.
- **FASM run-tests are unverified:** they are `@EnabledOnOs(WINDOWS)`, so only the
  Windows CI leg exercises them. FASM code generation was checked by hand and emits
  `_a_arr dq 11 dup 0.0` / `_a_arr_num_dims dq 1` for an implicit array.
- **One fix beyond the original scope:** a non-integer subscript on the *assignment*
  side was never type-checked and leaked a clang error
  (`getelementptr index must be an integer`). Pre-existing, fixed here because the
  new implicit-array path hit the same hole.

## Updated context

- Docs: `docs/languages/basic.md` — new "Variable and array types" section covering
  type resolution, optional `AS`, and implicit arrays
- Docs: `docs/system/basic-language.md` — why implicit arrays must be injected into
  the AST and cleared per parse, why prepending them ahead of `OPTION BASE` is safe
  and what would break it, the load-bearing branch order in `functionCall`, and when
  a `$` in a BASIC identifier needs escaping in a Kotlin test string (it does not,
  unless a letter follows it)
- Docs: `docs/Arrays.md` — note on implicit dimensioning under Overview

## How to verify

- Compile with the LLVM backend and `-Wundefined-variable`:
  `a%(3) = 7` / `PRINT a%(3)` warns `undefined array: a%` and prints `7`;
  without the flag it compiles silently.
- Check the type rules interact as expected: `DEFINT i-n` followed by
  `implicit(1) = 2.25 : PRINT implicit(1)` prints `2`, not `2.250000` — `implicit`
  starts with `i`, so `DEFINT` wins over the default `DOUBLE`.
- Check that an implicit array still honours the base:
  `OPTION BASE 1` / `a%(3) = 7` / `PRINT a%(3); lbound(a%); ubound(a%)`
  prints `7 1 10`.
- `DIM a(1) AS INTEGER : PRINT a(1, 7)` reports
  `array 'a' has 1 dimension, not 2` instead of `undefined function: a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
