### PR TITLE
Fix NPE on an undefined variable used as an operator operand

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,9 +6,17 @@ on:
   pull_request:
     branches: [ master, dev ]
 
+# Push covers every branch in this repo, so a same-repo PR would build twice.
+# Cancel superseded runs on the same ref while we are at it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-ubuntu:
     name: Build on Linux (${{ matrix.arch }})
+    # Only build a pull request when it comes from a fork; push handles the rest.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,19 +13,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-ubuntu:
-    name: Build on Linux (${{ matrix.arch }})
+  # A job skipped by the if below never expands its matrix, so a name using
+  # matrix.arch would show up raw in the checks list. Let GitHub derive the
+  # name from the job id and the matrix instead, and keep arch the only
+  # top-level matrix key so the derived name stays short.
+  build-linux:
     # Only build a pull request when it comes from a fork; push handles the rest.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        arch: [ x86_64, arm64 ]
         include:
-          - os: ubuntu-latest
-            arch: x86_64
-          - os: ubuntu-24.04-arm
-            arch: arm64
+          - arch: x86_64
+            os: ubuntu-latest
+          - arch: arm64
+            os: ubuntu-24.04-arm
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,9 +41,9 @@ jobs:
           brew link --overwrite --force llvm@20
           # Detect Homebrew prefix (different on ARM64 vs x86_64)
           BREW_PREFIX=$(brew --prefix)
-          echo "${BREW_PREFIX}/opt/llvm@20/bin" >> $GITHUB_PATH
-          echo "LDFLAGS=-L${BREW_PREFIX}/opt/llvm@20/lib" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I${BREW_PREFIX}/opt/llvm@20/include" >> $GITHUB_ENV
+          echo "${BREW_PREFIX}/opt/llvm@20/bin" >> "$GITHUB_PATH"
+          echo "LDFLAGS=-L${BREW_PREFIX}/opt/llvm@20/lib" >> "$GITHUB_ENV"
+          echo "CPPFLAGS=-I${BREW_PREFIX}/opt/llvm@20/include" >> "$GITHUB_ENV"
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,19 +13,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # A job skipped by the if below never expands its matrix, so a name using
+  # matrix.arch would show up raw in the checks list. Let GitHub derive the
+  # name from the job id and the matrix instead, and keep arch the only
+  # top-level matrix key so the derived name stays short.
   build-macos:
     # Only build a pull request when it comes from a fork; push handles the rest.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        runner: [macos-latest, macos-15-intel]
+        arch: [ arm64, x86_64 ]
         include:
-          - runner: macos-latest
-            arch: arm64
-          - runner: macos-15-intel
-            arch: x86_64
+          - arch: arm64
+            runner: macos-latest
+          - arch: x86_64
+            runner: macos-15-intel
     runs-on: ${{ matrix.runner }}
-    name: Build on macOS (${{ matrix.arch }})
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,8 +6,16 @@ on:
   pull_request:
     branches: [ master, dev ]
 
+# Push covers every branch in this repo, so a same-repo PR would build twice.
+# Cancel superseded runs on the same ref while we are at it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-macos:
+    # Only build a pull request when it comes from a fork; push handles the rest.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
         runner: [macos-latest, macos-15-intel]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,8 +6,16 @@ on:
   pull_request:
     branches: [ master, dev ]
 
+# Push covers every branch in this repo, so a same-repo PR would build twice.
+# Cancel superseded runs on the same ref while we are at it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-windows:
+    # Only build a pull request when it comes from a fork; push handles the rest.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6

--- a/docs/system/col-error-reporting.md
+++ b/docs/system/col-error-reporting.md
@@ -10,7 +10,9 @@ Adding a rule of this kind follows a fixed shape:
 
 Marker expression nodes implement `TypedExpression` and return the type the construct would have if it were valid (`ChainedRelationalExpression` returns `Bool`, `MalformedFloatLiteral` returns `F64`), so overload resolution does not fail before the dedicated error is reported.
 
-`IdentifierDerefExpression` breaks this rule. On an undefined variable, `IdentifierDerefSemanticsParser` reports the error and returns the node with its identifier's type still null; because the node is a `TypedExpression`, `AbstractTypeManager.getType` passes that null to the enclosing operator's type check, which dereferences it. So `1 + x` reports *undefined variable: x* and then crashes with a `NullPointerException` — likewise `-`, `*`, `<`, `/`, `div`, `and`, and unary `-`. A bare `x` and `not x` report cleanly. Tracked as issue #88; until it is fixed, a semantics test for an undefined name must use that name as the whole expression rather than as an operand.
+`IdentifierDerefSemanticsParser` follows the same rule on both its error paths — undefined variable, and a reference to a function that is not user-defined. Each reports the error and returns the node with `I64` set on its identifier. Returning the node untyped left `AbstractTypeManager.getType` handing a null to the enclosing operator's type check, so every operand position crashed with a `NullPointerException` (`1 + x`, `1 div x`, `-x`, `~x`, and the rest) while a bare `x` reported cleanly; that was issue #88. `AbstractSemanticsParserComponent.getType` backs the fix up by mapping a null type to the same `I64` it already returned for a thrown `SemanticsException`, so a component that forgets the rule degrades to a reported error instead of an internal crash.
+
+The `I64` fallback can add a follow-on error: `fun f() -> f64 := 1.0 + x` reports *undefined variable: x* and then *cannot add f64 and i64*. That is accepted — it matches the cascading error a bare undefined name already produced.
 
 Two details that are easy to get wrong:
 

--- a/docs/system/col-error-reporting.md
+++ b/docs/system/col-error-reporting.md
@@ -10,9 +10,9 @@ Adding a rule of this kind follows a fixed shape:
 
 Marker expression nodes implement `TypedExpression` and return the type the construct would have if it were valid (`ChainedRelationalExpression` returns `Bool`, `MalformedFloatLiteral` returns `F64`), so overload resolution does not fail before the dedicated error is reported.
 
-`IdentifierDerefSemanticsParser` follows the same rule on both its error paths — undefined variable, and a reference to a function that is not user-defined. Each reports the error and returns the node with `I64` set on its identifier. Returning the node untyped left `AbstractTypeManager.getType` handing a null to the enclosing operator's type check, so every operand position crashed with a `NullPointerException` (`1 + x`, `1 div x`, `-x`, `~x`, and the rest) while a bare `x` reported cleanly; that was issue #88. `AbstractSemanticsParserComponent.getType` backs the fix up by mapping a null type to the same `I64` it already returned for a thrown `SemanticsException`, so a component that forgets the rule degrades to a reported error instead of an internal crash.
+`IdentifierDerefSemanticsParser` follows the same rule on both its error paths — undefined variable, and a reference to a function that is not user-defined. Each reports the error and returns the node with `I64` set on its identifier, so the enclosing operator's type check gets a type and the undefined name is reported the same way in operand position (`1 + x`, `1 div x`, `-x`, `~x`) as on its own. `AbstractSemanticsParserComponent.getType` maps a null type to the same `I64`, so a component that returns an untyped node still degrades to a reported error rather than a `NullPointerException`.
 
-The `I64` fallback can add a follow-on error: `fun f() -> f64 := 1.0 + x` reports *undefined variable: x* and then *cannot add f64 and i64*. That is accepted — it matches the cascading error a bare undefined name already produced.
+The `I64` fallback can add a follow-on error: `fun f() -> f64 := 1.0 + x` reports *undefined variable: x* and then *cannot add f64 and i64*. That is accepted — it matches the cascading error a bare undefined name produces.
 
 Two details that are easy to get wrong:
 

--- a/jcc-base/src/main/java/se/dykstrom/jcc/common/semantics/AbstractSemanticsParserComponent.java
+++ b/jcc-base/src/main/java/se/dykstrom/jcc/common/semantics/AbstractSemanticsParserComponent.java
@@ -72,7 +72,11 @@ public abstract class AbstractSemanticsParserComponent<T extends TypeManager> {
 
     protected Type getType(final Expression expression) {
         try {
-            return types().getType(expression);
+            // An expression whose type could not be determined has already been reported as an
+            // error. Fall back to the same type as for a thrown exception, so that callers can
+            // keep collecting errors instead of failing on a null type.
+            final var type = types().getType(expression);
+            return (type != null) ? type : I64.INSTANCE;
         } catch (SemanticsException se) {
             reportError(expression, se.getMessage(), se);
             return I64.INSTANCE;

--- a/jcc-base/src/main/java/se/dykstrom/jcc/common/semantics/expression/IdentifierDerefSemanticsParser.java
+++ b/jcc-base/src/main/java/se/dykstrom/jcc/common/semantics/expression/IdentifierDerefSemanticsParser.java
@@ -27,6 +27,7 @@ import se.dykstrom.jcc.common.functions.UserDefinedFunction;
 import se.dykstrom.jcc.common.semantics.AbstractSemanticsParserComponent;
 import se.dykstrom.jcc.common.semantics.VariableUsageTracker;
 import se.dykstrom.jcc.common.types.AmbiguousType;
+import se.dykstrom.jcc.common.types.I64;
 
 import static java.util.stream.Collectors.toSet;
 
@@ -58,7 +59,7 @@ public class IdentifierDerefSemanticsParser<T extends TypeManager> extends Abstr
                 final var msg = "cannot use '" + name + "' as a function reference: only user-defined " +
                                 "functions can be referenced, not built-in or library functions";
                 reportError(expression, msg, new SemanticsException(msg));
-                return expression;
+                return withFallbackType(expression);
             }
             if (functions.size() == 1) {
                 // If there is only one function with this name, we have found a match
@@ -77,7 +78,16 @@ public class IdentifierDerefSemanticsParser<T extends TypeManager> extends Abstr
         } else {
             final var msg = "undefined variable: " + name;
             reportError(expression, msg, new UndefinedException(msg, name));
-            return expression;
+            return withFallbackType(expression);
         }
+    }
+
+    /**
+     * Returns the given expression with a fallback type set on its identifier. An identifier that
+     * could not be resolved has no type, and returning it as it is would leave the enclosing
+     * expression with a null type, crashing the type check of any operator it is an operand of.
+     */
+    private static Expression withFallbackType(final IdentifierDerefExpression expression) {
+        return expression.withIdentifier(expression.getIdentifier().withType(I64.INSTANCE));
     }
 }

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserAnonymousFunctionTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserAnonymousFunctionTests.kt
@@ -135,7 +135,7 @@ class ColSemanticsParserAnonymousFunctionTests : AbstractColSemanticsParserTests
     @Test
     fun shouldNotSeeEnclosingFunctionParameter() {
         parseAndExpectError(
-            "fun adder(n as i64) -> () -> i64 := fun() -> i64 := n",
+            "fun adder(n as i64) -> (i64) -> i64 := fun(x as i64) -> i64 := x + n",
             "undefined variable: n"
         )
     }
@@ -145,7 +145,7 @@ class ColSemanticsParserAnonymousFunctionTests : AbstractColSemanticsParserTests
         parseAndExpectError(
             """
             val limit := 10
-            val f := fun() -> i64 := limit
+            val f := fun() -> i64 := limit + 1
             """,
             "undefined variable: limit"
         )
@@ -154,7 +154,7 @@ class ColSemanticsParserAnonymousFunctionTests : AbstractColSemanticsParserTests
     @Test
     fun shouldNotSeeEnclosingAnonymousFunctionParameter() {
         parseAndExpectError(
-            "val f := fun(a as i64) -> () -> i64 := fun() -> i64 := a",
+            "val f := fun(a as i64) -> (i64) -> i64 := fun(b as i64) -> i64 := b * a",
             "undefined variable: a"
         )
     }

--- a/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserUserFunctionTests.kt
+++ b/jcc-col/src/test/kotlin/se/dykstrom/jcc/col/compiler/ColSemanticsParserUserFunctionTests.kt
@@ -458,6 +458,69 @@ class ColSemanticsParserUserFunctionTests : AbstractColSemanticsParserTests() {
         parseAndExpectError("fun foo() -> i64 := x", "undefined variable: x")
     }
 
+    // An undefined variable used as an operand must be reported like any other undefined
+    // variable, and not crash the type check of the enclosing operator, see issue #88
+
+    @Test
+    fun shouldNotParseUndefinedVariableInAddition() {
+        parseAndExpectError("fun foo() -> i64 := 1 + x", "undefined variable: x")
+    }
+
+    @Test
+    fun shouldNotParseUndefinedVariableInSubtraction() {
+        parseAndExpectError("fun foo() -> i64 := 1 - x", "undefined variable: x")
+    }
+
+    @Test
+    fun shouldNotParseUndefinedVariableInMultiplication() {
+        parseAndExpectError("fun foo() -> i64 := 1 * x", "undefined variable: x")
+    }
+
+    @Test
+    fun shouldNotParseUndefinedVariableInDivision() {
+        parseAndExpectError("fun foo() -> f64 := 1 / x", "undefined variable: x")
+    }
+
+    @Test
+    fun shouldNotParseUndefinedVariableInIntegerDivision() {
+        parseAndExpectError("fun foo() -> i64 := 1 div x", "undefined variable: x")
+    }
+
+    @Test
+    fun shouldNotParseUndefinedVariableInModulo() {
+        parseAndExpectError("fun foo() -> i64 := 1 mod x", "undefined variable: x")
+    }
+
+    @Test
+    fun shouldNotParseUndefinedVariableInComparison() {
+        parseAndExpectError("fun foo() -> bool := 1 < x", "undefined variable: x")
+    }
+
+    @Test
+    fun shouldNotParseUndefinedVariableInLogicalExpression() {
+        parseAndExpectError("fun foo() -> bool := true and x", "undefined variable: x")
+    }
+
+    @Test
+    fun shouldNotParseUndefinedVariableInBitwiseExpression() {
+        parseAndExpectError("fun foo() -> i64 := 1 & x", "undefined variable: x")
+    }
+
+    @Test
+    fun shouldNotParseNegatedUndefinedVariable() {
+        parseAndExpectError("fun foo() -> i64 := -x", "undefined variable: x")
+    }
+
+    @Test
+    fun shouldNotParseBitwiseNotOfUndefinedVariable() {
+        parseAndExpectError("fun foo() -> i64 := ~x", "undefined variable: x")
+    }
+
+    @Test
+    fun shouldNotParseLibraryFunctionReferenceAsOperand() {
+        parseAndExpectError("fun foo() -> i64 := 1 + println", "cannot use 'println' as a function reference")
+    }
+
     @Test
     fun shouldNotParseDuplicateArgs() {
         parseAndExpectError("fun foo(a as i64, a as f64) -> i64 := 0", "parameter 'a' is already defined")


### PR DESCRIPTION
## What is this

In COL, an undefined name used inside an expression was reported correctly and
then crashed the compiler with a NullPointerException. Anonymous functions
enforce their no-capture rule through exactly this diagnostic, so referencing an
enclosing parameter crashed instead of explaining itself. Fixes #88.

## Approach

- **Failed lookups get a type:** `IdentifierDerefSemanticsParser` returns the node with `I64` on its identifier.
- **I64 as the fallback:** what `getType` already returned for a thrown `SemanticsException`.
- **`getType` guards null too:** a backstop, so no other component can reintroduce the crash.
- **Both error branches, not just one:** the "cannot use as a function reference" branch leaked null identically; the issue did not list it.
- **No `Unknown` sentinel type:** it would touch every type manager and code generator.

## Risks / follow-ups

- **Follow-on type errors:** `fun f() -> f64 := 1.0 + x` reports *undefined variable: x* and then *cannot add f64 and i64*. This matches the cascading error a bare undefined name already produced.
- **Shared code:** the change is in `jcc-base`, so Tiny uses it too. Tiny was never affected — its identifiers already carry a type — and its tests still pass.

## Updated context

- Docs: `docs/system/col-error-reporting.md` — the paragraph documenting #88 as a live crash, and telling test authors to keep undefined names out of operand position, now records the fixed behaviour and the fallback-type convention.

## How to verify

- Compile `fun broken(n as i64) -> (i64) -> i64 := fun(x as i64) -> i64 := x + n` with `-fsyntax-only`. Expect a single `error: undefined variable: n` and no stack trace.
- Try an undefined name under other operators (`1 div x`, `~x`, `-x`) and confirm each names the variable rather than crashing.

## Also in this branch: CI trigger cleanup

Unrelated to the NPE fix, folded in here rather than opened separately. The
three build workflows ran twice for every pull request — once for the push to
the branch, once for the pull request itself.

- **Pull requests build only from forks:** a job-level `if` skips same-repo pull requests, which `push` already covers.
- **Push stays on every branch:** only macOS/ARM64 can be verified locally, so the other legs must run before a pull request exists.
- **Merge-result testing is the trade:** `push` builds the branch alone, never merged into its base — merge `dev` in before landing.
- **Concurrency cancels superseded runs:** keyed on the ref, `master` and `dev` included.

Verified on commit 90bd729: the three `pull_request` runs completed as
*skipped* with no runner time, the three `push` runs built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

